### PR TITLE
fix: no-angle-bracket-type-assertion fails with non-reference types (fixes #19)

### DIFF
--- a/lib/rules/no-angle-bracket-type-assertion.js
+++ b/lib/rules/no-angle-bracket-type-assertion.js
@@ -19,17 +19,18 @@ module.exports = {
 
     create: function(context) {
 
+        var sourceCode = context.getSourceCode();
+
         //----------------------------------------------------------------------
         // Public
         //----------------------------------------------------------------------
         return {
             TSTypeAssertionExpression: function(node) {
-                const type = node.typeAnnotation.typeAnnotation.typeName.name;
                 context.report({
                     node,
                     message: "Prefer 'as {{cast}}' instead of '<{{cast}}>' when doing type assertions",
                     data: {
-                        cast: type
+                        cast: sourceCode.getText(node.typeAnnotation.typeAnnotation)
                     }
                 });
             }

--- a/tests/lib/rules/no-angle-bracket-type-assertion.js
+++ b/tests/lib/rules/no-angle-bracket-type-assertion.js
@@ -31,7 +31,74 @@ class Generic<T> implements Foo {}
 
 const foo = {} as Foo<int>;
 const bar = new Generic<int>() as Foo;
-const array : Array<string> = [];
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "const array : Array<string> = [];",
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "const array : Array<string> = [];",
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "const a : number = 5 as number",
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "Prefer 'as number' instead of '<number>' when doing type assertions",
+                    row: 1,
+                    column: 20
+                }
+            ]
+        },
+        {
+            code: `
+const a : number = 5;
+const b : number = a as number;
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "Prefer 'as number' instead of '<number>' when doing type assertions",
+                    row: 3,
+                    column: 20
+                }
+            ]
+        },
+        {
+            code: "const a : Array<number> = [1] as Array<number>;",
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "Prefer 'as Array<number>' instead of '<Array<number>>' when doing type assertions",
+                    row: 1,
+                    column: 27
+                }
+            ]
+        },
+        {
+            code: `
+class A {}
+class B extends A {}
+
+const b : B = new B();
+const a : A = b as A;
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type A = {
+    num: number
+};
+
+const b = {
+    num: 5
+};
+
+const a: A = b as A;
             `,
             parser: "typescript-eslint-parser"
         }
@@ -48,7 +115,6 @@ class Generic<T> implements Foo {}
 
 const foo = <Foo>{};
 const bar = <Foo>new Generic<int>();
-const array : Array<string> = [];
             `,
             parser: "typescript-eslint-parser",
             errors: [
@@ -62,6 +128,80 @@ const array : Array<string> = [];
                     row: 9,
                     column: 13
                 },
+            ]
+        },
+        {
+            code: "const a : number = <number>5",
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "Prefer 'as number' instead of '<number>' when doing type assertions",
+                    row: 1,
+                    column: 20
+                }
+            ]
+        },
+        {
+            code: `
+const a : number = 5;
+const b : number = <number>a;
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "Prefer 'as number' instead of '<number>' when doing type assertions",
+                    row: 3,
+                    column: 20
+                }
+            ]
+        },
+        {
+            code: "const a : Array<number> = <Array<number>>[1];",
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "Prefer 'as Array<number>' instead of '<Array<number>>' when doing type assertions",
+                    row: 1,
+                    column: 27
+                }
+            ]
+        },
+        {
+            code: `
+class A {}
+class B extends A {}
+
+const b : B = new B();
+const a : A = <A>b;
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "Prefer 'as A' instead of '<A>' when doing type assertions",
+                    row: 6,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: `
+type A = {
+    num: number
+};
+
+const b = {
+    num: 5
+};
+
+const a: A = <A>b;
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "Prefer 'as A' instead of '<A>' when doing type assertions",
+                    row: 9,
+                    column: 14
+                }
             ]
         }
     ]


### PR DESCRIPTION
Modify to no-angle-bracket-type-assertion rule
Add more tests for the rle