### PR TITLE
no-use-before-define

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,6 @@ Then configure the rules you want to use under the rules section.
 * `typescript/no-explicit-any` - enforces the any type is not used.
 * `typescript/no-angle-bracket-type-assertion` - enforces the use of `as Type` assertions instead of `<Type>` assertions.
 * `typescript/no-namespace` - disallows the use of custom TypeScript modules and namespaces.
+* `typescript/no-use-before-define` - disallows the use of variables before they are defined
 * `typescript/prefer-namespace-keyword` - enforces the use of the keyword `namespace` over `module` to declare custom TypeScript modules.
 * `typescript/no-type-literal` - disallows the use of type aliases.

--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -10,7 +10,7 @@ This rule will warn when it encounters a reference to an identifier that has not
 
 Examples of **incorrect** code for this rule:
 
-```js
+```ts
 /*eslint no-use-before-define: "error"*/
 /*eslint-env es6*/
 
@@ -30,11 +30,14 @@ var b = 1;
     alert(c);
     let c = 1;
 }
+
+let myVar: StringOrNumber;
+type StringOrNumber = string | number;
 ```
 
 Examples of **correct** code for this rule:
 
-```js
+```ts
 /*eslint no-use-before-define: "error"*/
 /*eslint-env es6*/
 
@@ -55,6 +58,9 @@ function g() {
     let C;
     c++;
 }
+
+type StringOrNumber = string | number;
+let myVar: StringOrNumber;
 ```
 
 ## Options
@@ -81,6 +87,12 @@ function g() {
   This flag determines whether or not the rule checks variable declarations in upper scopes.
   If this is `true`, the rule warns every reference to a variable before the variable declaration.
   Otherwise, the rule ignores a reference if the declaration is in an upper scope, while still reporting the reference if it's in the same scope as the declaration.
+  Default is `true`.
+* `typedefs` (`boolean`, **added** in `eslint-plugin-typescript`) -
+  The flag which shows whether or not this rule checks type declarations.
+  If this is `true`, this rule warns every reference to a type before the type declaration.
+  Otherwise, ignores those references.
+  Type declarations are hoisted, so it's safe.
   Default is `true`.
 
 This rule accepts `"nofunc"` string as an option.
@@ -146,5 +158,17 @@ function baz() {
 
 var foo = 1;
 ```
+
+### typedefs
+
+Examples of **correct** code for the `{ "typedefs": false }` option:
+
+```ts
+/*eslint no-use-before-define: ["error", { "typedefs": false }]*/
+
+let myVar: StringOrNumber;
+type StringOrNumber = string | number;
+```
+
 
 Copied from [the original ESLint rule docs](https://github.com/eslint/eslint/blob/a113cd3/docs/rules/no-use-before-define.md)

--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -1,0 +1,150 @@
+# Disallow Early Use (no-use-before-define)
+
+In JavaScript, prior to ES6, variable and function declarations are hoisted to the top of a scope, so it's possible to use identifiers before their formal declarations in code. This can be confusing and some believe it is best to always declare variables and functions before using them.
+
+In ES6, block-level bindings (`let` and `const`) introduce a "temporal dead zone" where a `ReferenceError` will be thrown with any attempt to access the variable before its declaration.
+
+## Rule Details
+
+This rule will warn when it encounters a reference to an identifier that has not yet been declared.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-use-before-define: "error"*/
+/*eslint-env es6*/
+
+alert(a);
+var a = 10;
+
+f();
+function f() {}
+
+function g() {
+    return b;
+}
+var b = 1;
+
+// With blockBindings: true
+{
+    alert(c);
+    let c = 1;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-use-before-define: "error"*/
+/*eslint-env es6*/
+
+var a;
+a = 10;
+alert(a);
+
+function f() {}
+f(1);
+
+var b = 1;
+function g() {
+    return b;
+}
+
+// With blockBindings: true
+{
+    let C;
+    c++;
+}
+```
+
+## Options
+
+```json
+{
+    "no-use-before-define": ["error", { "functions": true, "classes": true }]
+}
+```
+
+* `functions` (`boolean`) -
+  The flag which shows whether or not this rule checks function declarations.
+  If this is `true`, this rule warns every reference to a function before the function declaration.
+  Otherwise, ignores those references.
+  Function declarations are hoisted, so it's safe.
+  Default is `true`.
+* `classes` (`boolean`) -
+  The flag which shows whether or not this rule checks class declarations of upper scopes.
+  If this is `true`, this rule warns every reference to a class before the class declaration.
+  Otherwise, ignores those references if the declaration is in upper function scopes.
+  Class declarations are not hoisted, so it might be danger.
+  Default is `true`.
+* `variables` (`boolean`) -
+  This flag determines whether or not the rule checks variable declarations in upper scopes.
+  If this is `true`, the rule warns every reference to a variable before the variable declaration.
+  Otherwise, the rule ignores a reference if the declaration is in an upper scope, while still reporting the reference if it's in the same scope as the declaration.
+  Default is `true`.
+
+This rule accepts `"nofunc"` string as an option.
+`"nofunc"` is the same as `{ "functions": false, "classes": true }`.
+
+### functions
+
+Examples of **correct** code for the `{ "functions": false }` option:
+
+```js
+/*eslint no-use-before-define: ["error", { "functions": false }]*/
+
+f();
+function f() {}
+```
+
+### classes
+
+Examples of **incorrect** code for the `{ "classes": false }` option:
+
+```js
+/*eslint no-use-before-define: ["error", { "classes": false }]*/
+/*eslint-env es6*/
+
+new A();
+class A {
+}
+```
+
+Examples of **correct** code for the `{ "classes": false }` option:
+
+```js
+/*eslint no-use-before-define: ["error", { "classes": false }]*/
+/*eslint-env es6*/
+
+function foo() {
+    return new A();
+}
+
+class A {
+}
+```
+
+### variables
+
+Examples of **incorrect** code for the `{ "variables": false }` option:
+
+```js
+/*eslint no-use-before-define: ["error", { "variables": false }]*/
+
+console.log(foo);
+var foo = 1;
+```
+
+Examples of **correct** code for the `{ "variables": false }` option:
+
+```js
+/*eslint no-use-before-define: ["error", { "variables": false }]*/
+
+function baz() {
+    console.log(foo);
+}
+
+var foo = 1;
+```
+
+Copied from [the original ESLint rule docs](https://github.com/eslint/eslint/blob/a113cd3/docs/rules/no-use-before-define.md)

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -1,0 +1,264 @@
+/**
+ * @fileoverview Rule to flag use of variables before they are defined
+ * @author Ilya Volodin
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const SENTINEL_TYPE = /^(?:(?:Function|Class)(?:Declaration|Expression)|ArrowFunctionExpression|CatchClause|ImportDeclaration|ExportNamedDeclaration)$/;
+const FOR_IN_OF_TYPE = /^For(?:In|Of)Statement$/;
+
+/**
+ * Parses a given value as options.
+ *
+ * @param {any} options - A value to parse.
+ * @returns {Object} The parsed options.
+ */
+function parseOptions(options) {
+    let functions = true;
+    let classes = true;
+    let variables = true;
+
+    if (typeof options === "string") {
+        functions = (options !== "nofunc");
+    } else if (typeof options === "object" && options !== null) {
+        functions = options.functions !== false;
+        classes = options.classes !== false;
+        variables = options.variables !== false;
+    }
+
+    return { functions, classes, variables };
+}
+
+/**
+ * Checks whether or not a given variable is a function declaration.
+ *
+ * @param {eslint-scope.Variable} variable - A variable to check.
+ * @returns {boolean} `true` if the variable is a function declaration.
+ */
+function isFunction(variable) {
+    return variable.defs[0].type === "FunctionName";
+}
+
+/**
+ * Checks whether or not a given variable is a class declaration in an upper function scope.
+ *
+ * @param {eslint-scope.Variable} variable - A variable to check.
+ * @param {eslint-scope.Reference} reference - A reference to check.
+ * @returns {boolean} `true` if the variable is a class declaration.
+ */
+function isOuterClass(variable, reference) {
+    return (
+        variable.defs[0].type === "ClassName" &&
+        variable.scope.variableScope !== reference.from.variableScope
+    );
+}
+
+/**
+* Checks whether or not a given variable is a variable declaration in an upper function scope.
+* @param {eslint-scope.Variable} variable - A variable to check.
+* @param {eslint-scope.Reference} reference - A reference to check.
+* @returns {boolean} `true` if the variable is a variable declaration.
+*/
+function isOuterVariable(variable, reference) {
+    return (
+        variable.defs[0].type === "Variable" &&
+        variable.scope.variableScope !== reference.from.variableScope
+    );
+}
+
+/**
+ * Checks whether or not a given location is inside of the range of a given node.
+ *
+ * @param {ASTNode} node - An node to check.
+ * @param {number} location - A location to check.
+ * @returns {boolean} `true` if the location is inside of the range of the node.
+ */
+function isInRange(node, location) {
+    return node && node.range[0] <= location && location <= node.range[1];
+}
+
+/**
+ * Checks whether or not a given reference is inside of the initializers of a given variable.
+ *
+ * This returns `true` in the following cases:
+ *
+ *     var a = a
+ *     var [a = a] = list
+ *     var {a = a} = obj
+ *     for (var a in a) {}
+ *     for (var a of a) {}
+ *
+ * @param {Variable} variable - A variable to check.
+ * @param {Reference} reference - A reference to check.
+ * @returns {boolean} `true` if the reference is inside of the initializers.
+ */
+function isInInitializer(variable, reference) {
+    if (variable.scope !== reference.from) {
+        return false;
+    }
+
+    let node = variable.identifiers[0].parent;
+    const location = reference.identifier.range[1];
+
+    while (node) {
+        if (node.type === "VariableDeclarator") {
+            if (isInRange(node.init, location)) {
+                return true;
+            }
+            if (FOR_IN_OF_TYPE.test(node.parent.parent.type) &&
+                isInRange(node.parent.parent.right, location)
+            ) {
+                return true;
+            }
+            break;
+        } else if (node.type === "AssignmentPattern") {
+            if (isInRange(node.right, location)) {
+                return true;
+            }
+        } else if (SENTINEL_TYPE.test(node.type)) {
+            break;
+        }
+
+        node = node.parent;
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow the use of variables before they are defined",
+            category: "Variables",
+            recommended: false
+        },
+
+        schema: [
+            {
+                oneOf: [
+                    {
+                        enum: ["nofunc"]
+                    },
+                    {
+                        type: "object",
+                        properties: {
+                            functions: { type: "boolean" },
+                            classes: { type: "boolean" },
+                            variables: { type: "boolean" }
+                        },
+                        additionalProperties: false
+                    }
+                ]
+            }
+        ]
+    },
+
+    create(context) {
+        const options = parseOptions(context.options[0]);
+
+        /**
+         * Determines whether a given use-before-define case should be reported according to the options.
+         * @param {eslint-scope.Variable} variable The variable that gets used before being defined
+         * @param {eslint-scope.Reference} reference The reference to the variable
+         * @returns {boolean} `true` if the usage should be reported
+         */
+        function isForbidden(variable, reference) {
+            if (isFunction(variable)) {
+                return options.functions;
+            }
+            if (isOuterClass(variable, reference)) {
+                return options.classes;
+            }
+            if (isOuterVariable(variable, reference)) {
+                return options.variables;
+            }
+            return true;
+        }
+
+        /**
+         * Finds and validates all variables in a given scope.
+         * @param {Scope} scope The scope object.
+         * @returns {void}
+         * @private
+         */
+        function findVariablesInScope(scope) {
+            scope.references.forEach(reference => {
+                const variable = reference.resolved;
+
+                // Skips when the reference is:
+                // - initialization's.
+                // - referring to an undefined variable.
+                // - referring to a global environment variable (there're no identifiers).
+                // - located preceded by the variable (except in initializers).
+                // - allowed by options.
+                if (reference.init ||
+                    !variable ||
+                    variable.identifiers.length === 0 ||
+                    (variable.identifiers[0].range[1] < reference.identifier.range[1] && !isInInitializer(variable, reference)) ||
+                    !isForbidden(variable, reference)
+                ) {
+                    return;
+                }
+
+                // Reports.
+                context.report({
+                    node: reference.identifier,
+                    message: "'{{name}}' was used before it was defined.",
+                    data: reference.identifier
+                });
+            });
+        }
+
+        /**
+         * Validates variables inside of a node's scope.
+         * @param {ASTNode} node The node to check.
+         * @returns {void}
+         * @private
+         */
+        function findVariables() {
+            const scope = context.getScope();
+
+            findVariablesInScope(scope);
+        }
+
+        const ruleDefinition = {
+            "Program:exit"(node) {
+                const scope = context.getScope(),
+                    ecmaFeatures = context.parserOptions.ecmaFeatures || {};
+
+                findVariablesInScope(scope);
+
+                // both Node.js and Modules have an extra scope
+                if (ecmaFeatures.globalReturn || node.sourceType === "module") {
+                    findVariablesInScope(scope.childScopes[0]);
+                }
+            }
+        };
+
+        if (context.parserOptions.ecmaVersion >= 6) {
+            ruleDefinition["BlockStatement:exit"] =
+                ruleDefinition["SwitchStatement:exit"] = findVariables;
+
+            ruleDefinition["ArrowFunctionExpression:exit"] = function(node) {
+                if (node.body.type !== "BlockStatement") {
+                    findVariables();
+                }
+            };
+        } else {
+            ruleDefinition["FunctionExpression:exit"] =
+                ruleDefinition["FunctionDeclaration:exit"] =
+                ruleDefinition["ArrowFunctionExpression:exit"] = findVariables;
+        }
+
+        return ruleDefinition;
+    }
+};

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -1,5 +1,7 @@
 /**
  * @fileoverview Rule to flag use of variables before they are defined
+ * @copyright ESLint
+ * @see https://github.com/eslint/eslint/blob/a113cd3/lib/rules/no-use-before-define.js
  * @author Ilya Volodin
  */
 

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -3,6 +3,7 @@
  * @copyright ESLint
  * @see https://github.com/eslint/eslint/blob/a113cd3/lib/rules/no-use-before-define.js
  * @author Ilya Volodin
+ * @author Jed Fox
  */
 
 "use strict";
@@ -24,6 +25,7 @@ function parseOptions(options) {
     let functions = true;
     let classes = true;
     let variables = true;
+    let typedefs = true;
 
     if (typeof options === "string") {
         functions = (options !== "nofunc");
@@ -31,9 +33,10 @@ function parseOptions(options) {
         functions = options.functions !== false;
         classes = options.classes !== false;
         variables = options.variables !== false;
+        typedefs = options.typedefs !== false;
     }
 
-    return { functions, classes, variables };
+    return { functions, classes, variables, typedefs };
 }
 
 /**
@@ -61,15 +64,27 @@ function isOuterClass(variable, reference) {
 }
 
 /**
-* Checks whether or not a given variable is a variable declaration in an upper function scope.
-* @param {eslint-scope.Variable} variable - A variable to check.
-* @param {eslint-scope.Reference} reference - A reference to check.
-* @returns {boolean} `true` if the variable is a variable declaration.
-*/
+ * Checks whether or not a given variable is a variable declaration in an upper function scope.
+ * @param {eslint-scope.Variable} variable - A variable to check.
+ * @param {eslint-scope.Reference} reference - A reference to check.
+ * @returns {boolean} `true` if the variable is a variable declaration.
+ */
 function isOuterVariable(variable, reference) {
     return (
         variable.defs[0].type === "Variable" &&
         variable.scope.variableScope !== reference.from.variableScope
+    );
+}
+
+/**
+ * Checks whether or not a given variable is a type declaration.
+ * @param {eslint-scope.Variable} variable - A type to check.
+ * @returns {boolean} `true` if the variable is a type.
+ */
+function isType(variable) {
+    return (
+        variable.defs[0].type === "Variable" &&
+        variable.defs[0].parent.kind === "type"
     );
 }
 
@@ -155,7 +170,8 @@ module.exports = {
                         properties: {
                             functions: { type: "boolean" },
                             classes: { type: "boolean" },
-                            variables: { type: "boolean" }
+                            variables: { type: "boolean" },
+                            typedefs: { type: "boolean" }
                         },
                         additionalProperties: false
                     }
@@ -179,6 +195,9 @@ module.exports = {
             }
             if (isOuterClass(variable, reference)) {
                 return options.classes;
+            }
+            if (isType(variable) && !options.typedefs) {
+                return false;
             }
             if (isOuterVariable(variable, reference)) {
                 return options.variables;

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "author": "Nicholas C. Zakas",
   "main": "lib/index.js",
   "scripts": {
-    "lint": "eslint lib/",
-    "lint:fix": "eslint --fix lib/",
+    "lint": "eslint lib/ tests/",
+    "lint:fix": "eslint lib/ test/ --fix",
     "mocha": "mocha tests --recursive",
     "test": "npm run lint && npm run mocha"
   },

--- a/tests/.eslintrc.yml
+++ b/tests/.eslintrc.yml
@@ -1,0 +1,2 @@
+rules:
+  node/no-unpublished-require: off # we’re using devDeps here.

--- a/tests/lib/rules/explicit-member-accessibility.js
+++ b/tests/lib/rules/explicit-member-accessibility.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-let rule = require("../../../lib/rules/explicit-member-accessibility"),
+const rule = require("../../../lib/rules/explicit-member-accessibility"),
     RuleTester = require("eslint").RuleTester;
 
 
@@ -16,7 +16,8 @@ let rule = require("../../../lib/rules/explicit-member-accessibility"),
 // Tests
 //------------------------------------------------------------------------------
 
-let ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
+
 ruleTester.run("explicit-member-accessibility", rule, {
 
     valid: [

--- a/tests/lib/rules/interface-name-prefix.js
+++ b/tests/lib/rules/interface-name-prefix.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-let rule = require("../../../lib/rules/interface-name-prefix"),
+const rule = require("../../../lib/rules/interface-name-prefix"),
     RuleTester = require("eslint").RuleTester;
 
 
@@ -16,7 +16,8 @@ let rule = require("../../../lib/rules/interface-name-prefix"),
 // Tests
 //------------------------------------------------------------------------------
 
-let ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
+
 ruleTester.run("interface-name-prefix", rule, {
 
     valid: [

--- a/tests/lib/rules/no-angle-bracket-type-assertion.js
+++ b/tests/lib/rules/no-angle-bracket-type-assertion.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-let rule = require("../../../lib/rules/no-angle-bracket-type-assertion"),
+const rule = require("../../../lib/rules/no-angle-bracket-type-assertion"),
     RuleTester = require("eslint").RuleTester;
 
 
@@ -16,7 +16,8 @@ let rule = require("../../../lib/rules/no-angle-bracket-type-assertion"),
 // Tests
 //------------------------------------------------------------------------------
 
-let ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
+
 ruleTester.run("no-angle-bracket-type-assertion", rule, {
 
     valid: [
@@ -127,7 +128,7 @@ const bar = <Foo>new Generic<int>();
                     message: "Prefer 'as Foo' instead of '<Foo>' when doing type assertions",
                     row: 9,
                     column: 13
-                },
+                }
             ]
         },
         {

--- a/tests/lib/rules/no-explicit-any.js
+++ b/tests/lib/rules/no-explicit-any.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-let rule = require("../../../lib/rules/no-explicit-any"),
+const rule = require("../../../lib/rules/no-explicit-any"),
     RuleTester = require("eslint").RuleTester;
 
 
@@ -16,7 +16,8 @@ let rule = require("../../../lib/rules/no-explicit-any"),
 // Tests
 //------------------------------------------------------------------------------
 
-let ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
+
 ruleTester.run("no-explicit-any", rule, {
 
     valid: [

--- a/tests/lib/rules/no-namespace.js
+++ b/tests/lib/rules/no-namespace.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-let rule = require("../../../lib/rules/no-namespace"),
+const rule = require("../../../lib/rules/no-namespace"),
     RuleTester = require("eslint").RuleTester;
 
 
@@ -16,7 +16,8 @@ let rule = require("../../../lib/rules/no-namespace"),
 // Tests
 //------------------------------------------------------------------------------
 
-let ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
+
 ruleTester.run("no-namespace", rule, {
     valid: [
         {

--- a/tests/lib/rules/no-triple-slash-reference.js
+++ b/tests/lib/rules/no-triple-slash-reference.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-let rule = require("../../../lib/rules/no-triple-slash-reference"),
+const rule = require("../../../lib/rules/no-triple-slash-reference"),
     RuleTester = require("eslint").RuleTester;
 
 
@@ -16,7 +16,8 @@ let rule = require("../../../lib/rules/no-triple-slash-reference"),
 // Tests
 //------------------------------------------------------------------------------
 
-let ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
+
 ruleTester.run("no-triple-slash-reference", rule, {
 
     valid: [

--- a/tests/lib/rules/no-type-alias.js
+++ b/tests/lib/rules/no-type-alias.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var rule = require("../../../lib/rules/no-type-alias"),
+const rule = require("../../../lib/rules/no-type-alias"),
     RuleTester = require("eslint").RuleTester;
 
 
@@ -16,7 +16,8 @@ var rule = require("../../../lib/rules/no-type-alias"),
 // Tests
 //------------------------------------------------------------------------------
 
-var ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
+
 ruleTester.run("no-type-alias", rule, {
 
     valid: [
@@ -32,7 +33,7 @@ ruleTester.run("no-type-alias", rule, {
         },
         {
             code: "type Foo = 'a' | 'b';",
-            options: [{ allowAliases: true}],
+            options: [{ allowAliases: true }],
             parser: "typescript-eslint-parser"
         },
         {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -40,7 +40,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "@ClassDecoratorFactory()",
                 "export class Foo {}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -48,7 +48,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "@ClassDecorator",
                 "export class Foo {}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -58,7 +58,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "   get bar() {}",
                 "}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -68,7 +68,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "   set bar() {}",
                 "}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -78,7 +78,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "   bar() {}",
                 "}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -88,7 +88,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "   static bar() {}",
                 "}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -99,7 +99,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "   }",
                 "}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -110,7 +110,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "   }",
                 "}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -121,7 +121,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "   }",
                 "}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -132,7 +132,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "   }",
                 "}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -143,7 +143,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "   click = new EventEmitter();",
                 "}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -155,7 +155,7 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "   static prop2;",
                 "}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
@@ -167,16 +167,16 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "   y;",
                 "}"
             ].join("\n"),
-            parser,
+            parser
         },
         {
             code: [
                 "interface Base {}",
                 "class Thing implements Base {}",
-                "new Thing()",
+                "new Thing()"
             ].join("\n"),
-            parser,
-        },
+            parser
+        }
     ],
 
     invalid: [
@@ -191,6 +191,6 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 line: 1,
                 column: 10
             }]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -1,0 +1,127 @@
+/**
+ * @fileoverview Tests for no-use-before-define rule.
+ * @author Ilya Volodin
+ * @author Jed Fox
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-use-before-define"),
+    RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-use-before-define", rule, {
+    valid: [
+        "var a=10; alert(a);",
+        "function b(a) { alert(a); }",
+        "Object.hasOwnProperty.call(a);",
+        "function a() { alert(arguments);}",
+        { code: "a(); function a() { alert(arguments); }", options: ["nofunc"] },
+        { code: "(() => { var a = 42; alert(a); })();", parserOptions: { ecmaVersion: 6 } },
+        { code: "a(); try { throw new Error() } catch (a) {}" },
+        { code: "class A {} new A();", parserOptions: { ecmaVersion: 6 } },
+        "var a = 0, b = a;",
+        { code: "var {a = 0, b = a} = {};", parserOptions: { ecmaVersion: 6 } },
+        { code: "var [a = 0, b = a] = {};", parserOptions: { ecmaVersion: 6 } },
+        "function foo() { foo(); }",
+        "var foo = function() { foo(); };",
+        { code: "var a; for (a in a) {}" },
+        { code: "var a; for (a of a) {}", parserOptions: { ecmaVersion: 6 } },
+
+        // Block-level bindings
+        { code: "\"use strict\"; a(); { function a() {} }", parserOptions: { ecmaVersion: 6 } },
+        { code: "\"use strict\"; { a(); function a() {} }", options: ["nofunc"], parserOptions: { ecmaVersion: 6 } },
+        { code: "switch (foo) { case 1:  { a(); } default: { let a; }}", parserOptions: { ecmaVersion: 6 } },
+        { code: "a(); { let a = function () {}; }", parserOptions: { ecmaVersion: 6 } },
+
+        // object style options
+        { code: "a(); function a() { alert(arguments); }", options: [{ functions: false }] },
+        { code: "\"use strict\"; { a(); function a() {} }", options: [{ functions: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo() { new A(); } class A {};", options: [{ classes: false }], parserOptions: { ecmaVersion: 6 } },
+
+        // "variables" option
+        {
+            code: "function foo() { bar; } var bar;",
+            options: [{ variables: false }]
+        },
+        {
+            code: "var foo = () => bar; var bar;",
+            options: [{ variables: false }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
+        // "typedefs" option
+        {
+            code: "var x: Foo = 2; type Foo = string | number",
+            options: [{ typedefs: false }],
+            parser: "typescript-eslint-parser"
+        }
+    ],
+    invalid: [
+        { code: "a++; var a=19;", parserOptions: { sourceType: "module" }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "a++; var a=19;", parserOptions: { parserOptions: { ecmaVersion: 6 } }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "a++; var a=19;", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "a(); var a=function() {};", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "alert(a[1]); var a=[1,3];", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "a(); function a() { alert(b); var b=10; a(); }", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }, { message: "'b' was used before it was defined.", type: "Identifier" }] },
+        { code: "a(); var a=function() {};", options: ["nofunc"], errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "(() => { alert(a); var a = 42; })();", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "(() => a())(); function a() { }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "\"use strict\"; a(); { function a() {} }", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "a(); try { throw new Error() } catch (foo) {var a;}", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "var f = () => a; var a;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "new A(); class A {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
+        { code: "function foo() { new A(); } class A {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
+        { code: "new A(); var A = class {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
+        { code: "function foo() { new A(); } var A = class {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
+
+        // Block-level bindings
+        { code: "a++; { var a; }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "\"use strict\"; { a(); function a() {} }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "{a; let a = 1}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "switch (foo) { case 1: a();\n default: \n let a;}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "if (true) { function foo() { a; } let a;}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+
+        // object style options
+        { code: "a(); var a=function() {};", options: [{ functions: false, classes: false }], errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "new A(); class A {};", options: [{ functions: false, classes: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
+        { code: "new A(); var A = class {};", options: [{ classes: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
+        { code: "function foo() { new A(); } var A = class {};", options: [{ classes: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'A' was used before it was defined.", type: "Identifier" }] },
+
+        // invalid initializers
+        { code: "var a = a;", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "let a = a + b;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "const a = foo(a);", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "function foo(a = a) {}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "var {a = a} = [];", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "var [a = a] = [];", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "var {b = a, a} = {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "var [b = a, a] = {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "var {a = 0} = a;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "var [a = 0] = a;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "for (var a in a) {}", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "for (var a of a) {}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+
+        // "variables" option
+        {
+            code: "function foo() { bar; var bar = 1; } var bar;",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ variables: false }],
+            errors: [{ message: "'bar' was used before it was defined.", type: "Identifier" }]
+        },
+        {
+            code: "foo; var foo;",
+            options: [{ variables: false }],
+            errors: [{ message: "'foo' was used before it was defined.", type: "Identifier" }]
+        }
+    ]
+});

--- a/tests/lib/rules/prefer-namespace-keyword.js
+++ b/tests/lib/rules/prefer-namespace-keyword.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-let rule = require("../../../lib/rules/prefer-namespace-keyword"),
+const rule = require("../../../lib/rules/prefer-namespace-keyword"),
     RuleTester = require("eslint").RuleTester;
 
 
@@ -16,7 +16,8 @@ let rule = require("../../../lib/rules/prefer-namespace-keyword"),
 // Tests
 //------------------------------------------------------------------------------
 
-let ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
+
 ruleTester.run("prefer-namespace-keyword", rule, {
     valid: [
         {
@@ -41,7 +42,7 @@ ruleTester.run("prefer-namespace-keyword", rule, {
                     message: "Use namespace instead of module to declare custom TypeScript modules",
                     output: "namespace foo { }",
                     row: 1,
-                    column: 1,
+                    column: 1
                 }
             ]
         },

--- a/tests/lib/rules/type-annotation-spacing.js
+++ b/tests/lib/rules/type-annotation-spacing.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-let rule = require("../../../lib/rules/type-annotation-spacing"),
+const rule = require("../../../lib/rules/type-annotation-spacing"),
     RuleTester = require("eslint").RuleTester;
 
 
@@ -16,7 +16,8 @@ let rule = require("../../../lib/rules/type-annotation-spacing"),
 // Tests
 //------------------------------------------------------------------------------
 
-let ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
+
 ruleTester.run("type-annotation-spacing", rule, {
 
     valid: [


### PR DESCRIPTION
This adds the `no-use-before-define` rule from core ESLint, with a new `typedefs` option to ignore errors coming from `type` declarations.