### PR TITLE
Fix: no-explicit-any Rule does not check generic type (fix #26)

### DIFF
--- a/docs/rules/no-explicit-any.md
+++ b/docs/rules/no-explicit-any.md
@@ -14,21 +14,77 @@ an `any` type from being implied by the compiler, but doesn't prevent
 The following patterns are considered warnings:
 
 ```ts
-const age : any = "seventeen"
+const age: any = "seventeen"
 ```
 
 ```ts
-function greet () : any {}
+const ages: any[] = ["seventeen"]
+```
+
+```ts
+const ages: Array<any> = ["seventeen"]
+```
+
+```ts
+function greet(): any {}
+```
+
+```ts
+function greet(): any[] {}
+```
+
+```ts
+function greet(): Array<any> {}
+```
+
+```ts
+function greet(): Array<Array<any>> {}
+```
+
+```ts
+function greet(param: Array<any>): string {}
+```
+
+```ts
+function greet(param: Array<any>): Array<any> {}
 ```
 
 The following patterns are not warnings:
 
 ```ts
-const age : number = 17
+const age: number = 17
 ```
 
 ```ts
-function greet () : string {}
+const ages: number[] = [17]
+```
+
+```ts
+const ages: Array<number> = [17]
+```
+
+```ts
+function greet(): string {}
+```
+
+```ts
+function greet(): string[] {}
+```
+
+```ts
+function greet(): Array<string> {}
+```
+
+```ts
+function greet(): Array<Array<string>> {}
+```
+
+```ts
+function greet(param: Array<string>): string {}
+```
+
+```ts
+function greet(param: Array<string>): Array<string> {}
 ```
 
 ## When Not To Use It

--- a/tests/lib/rules/no-explicit-any.js
+++ b/tests/lib/rules/no-explicit-any.js
@@ -11,7 +11,6 @@
 let rule = require("../../../lib/rules/no-explicit-any"),
     RuleTester = require("eslint").RuleTester;
 
-
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -21,31 +20,670 @@ ruleTester.run("no-explicit-any", rule, {
 
     valid: [
         {
-            code: "const number : number = 1",
+            code: "const number: number = 1",
             parser: "typescript-eslint-parser"
         },
         {
-            code: "function greet () : string {}",
+            code: "function greet(): string {}",
             parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function greet(): Array<string> {}",
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function greet(): string[] {}",
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function greet(): Array<Array<string>> {}",
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function greet(): Array<string[]> {}",
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function greet(param: Array<string>): Array<string> {}",
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Greeter {
+    message: string;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Greeter {
+    message: Array<string>;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Greeter {
+    message: string[];
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Greeter {
+    message: Array<Array<string>>;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Greeter {
+    message: Array<string[]>;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Greeter {
+    message: string;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Greeter {
+    message: Array<string>;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Greeter {
+    message: string[];
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Greeter {
+    message: Array<Array<string>>;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Greeter {
+    message: Array<string[]>;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type obj = {
+    message: string;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type obj = {
+    message: Array<string>;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type obj = {
+    message: string[];
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type obj = {
+    message: Array<Array<string>>;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type obj = {
+    message: Array<string[]>;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type obj = {
+    message: string | number; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 23
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string | Array<string>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 29
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string | string[]; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 29
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string | Array<Array<string>>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 29
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string & number; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 23
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string & Array<string>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 29
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string & string[]; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 29
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string & Array<Array<string>>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 29
+            }]
         }
     ],
     invalid: [
         {
-            code: "const number : any = 1",
+            code: "const number: any = 1",
             parser: "typescript-eslint-parser",
             errors: [{
                 message: "Unexpected any. Specify a different type.",
                 line: 1,
-                column: 16
+                column: 15
             }]
         },
         {
-            code: "function generic () : any {}",
+            code: "function generic(): any {}",
             parser: "typescript-eslint-parser",
             errors: [{
                 message: "Unexpected any. Specify a different type.",
                 line: 1,
+                column: 21
+            }]
+        },
+        {
+            code: "function generic(): Array<any> {}",
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 1,
+                column: 27
+            }]
+        },
+        {
+            code: "function generic(): any[] {}",
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 1,
+                column: 21
+            }]
+        },
+        {
+            code: "function generic(param: Array<any>): number {}",
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 1,
+                column: 31
+            }]
+        },
+        {
+            code: "function generic(param: any[]): number {}",
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 1,
+                column: 25
+            }]
+        },
+        {
+            code: "function generic(param: Array<any>): Array<any> {}",
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "Unexpected any. Specify a different type.",
+                    line: 1,
+                    column: 31
+                },
+                {
+                    message: "Unexpected any. Specify a different type.",
+                    line: 1,
+                    column: 44
+                }
+            ]
+        },
+        {
+            code: "function generic(): Array<Array<any>> {}",
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 1,
+                column: 33
+            }]
+        },
+        {
+            code: "function generic(): Array<any[]> {}",
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 1,
+                column: 27
+            }]
+        },
+        {
+            code: `
+class Greeter {
+    message: any;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 14
+            }]
+        },
+        {
+            code: `
+class Greeter {
+    message: Array<any>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 20
+            }]
+        },
+        {
+            code: `
+class Greeter {
+    message: any[]; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 14
+            }]
+        },
+        {
+            code: `
+class Greeter {
+    message: Array<Array<any>>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 26
+            }]
+        },
+        {
+            code: `
+class Greeter {
+    message: Array<any[]>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 20
+            }]
+        },
+        {
+            code: `
+interface Greeter {
+    message: any; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 14
+            }]
+        },
+        {
+            code: `
+interface Greeter {
+    message: Array<any>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 20
+            }]
+        },
+        {
+            code: `
+interface Greeter {
+    message: any[]; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 14
+            }]
+        },
+        {
+            code: `
+interface Greeter {
+    message: Array<Array<any>>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 26
+            }]
+        },
+        {
+            code: `
+interface Greeter {
+    message: Array<any[]>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 20
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: any; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 14
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: Array<any>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 20
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: any[]; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 14
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: Array<Array<any>>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 26
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: Array<any[]>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 20
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string | any; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
                 column: 23
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string | Array<any>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 29
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string | any[]; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 23
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string | Array<Array<any>>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 35
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string | Array<any[]>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 29
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string & any; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 23
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string & Array<any>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 29
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string & any[]; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 23
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string & Array<Array<any>>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 35
+            }]
+        },
+        {
+            code: `
+type obj = {
+    message: string & Array<any[]>; 
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 29
             }]
         }
     ]

--- a/tests/lib/rules/no-explicit-any.js
+++ b/tests/lib/rules/no-explicit-any.js
@@ -173,12 +173,7 @@ type obj = {
     message: string | number; 
 }
             `,
-            parser: "typescript-eslint-parser",
-            errors: [{
-                message: "Unexpected any. Specify a different type.",
-                line: 3,
-                column: 23
-            }]
+            parser: "typescript-eslint-parser"
         },
         {
             code: `
@@ -186,12 +181,7 @@ type obj = {
     message: string | Array<string>; 
 }
             `,
-            parser: "typescript-eslint-parser",
-            errors: [{
-                message: "Unexpected any. Specify a different type.",
-                line: 3,
-                column: 29
-            }]
+            parser: "typescript-eslint-parser"
         },
         {
             code: `
@@ -199,12 +189,7 @@ type obj = {
     message: string | string[]; 
 }
             `,
-            parser: "typescript-eslint-parser",
-            errors: [{
-                message: "Unexpected any. Specify a different type.",
-                line: 3,
-                column: 29
-            }]
+            parser: "typescript-eslint-parser"
         },
         {
             code: `
@@ -212,12 +197,7 @@ type obj = {
     message: string | Array<Array<string>>; 
 }
             `,
-            parser: "typescript-eslint-parser",
-            errors: [{
-                message: "Unexpected any. Specify a different type.",
-                line: 3,
-                column: 29
-            }]
+            parser: "typescript-eslint-parser"
         },
         {
             code: `
@@ -225,12 +205,7 @@ type obj = {
     message: string & number; 
 }
             `,
-            parser: "typescript-eslint-parser",
-            errors: [{
-                message: "Unexpected any. Specify a different type.",
-                line: 3,
-                column: 23
-            }]
+            parser: "typescript-eslint-parser"
         },
         {
             code: `
@@ -238,12 +213,7 @@ type obj = {
     message: string & Array<string>; 
 }
             `,
-            parser: "typescript-eslint-parser",
-            errors: [{
-                message: "Unexpected any. Specify a different type.",
-                line: 3,
-                column: 29
-            }]
+            parser: "typescript-eslint-parser"
         },
         {
             code: `
@@ -251,12 +221,7 @@ type obj = {
     message: string & string[]; 
 }
             `,
-            parser: "typescript-eslint-parser",
-            errors: [{
-                message: "Unexpected any. Specify a different type.",
-                line: 3,
-                column: 29
-            }]
+            parser: "typescript-eslint-parser"
         },
         {
             code: `
@@ -264,12 +229,7 @@ type obj = {
     message: string & Array<Array<string>>; 
 }
             `,
-            parser: "typescript-eslint-parser",
-            errors: [{
-                message: "Unexpected any. Specify a different type.",
-                line: 3,
-                column: 29
-            }]
+            parser: "typescript-eslint-parser"
         }
     ],
     invalid: [

--- a/tests/lib/rules/no-explicit-any.js
+++ b/tests/lib/rules/no-explicit-any.js
@@ -364,6 +364,19 @@ type obj = {
         {
             code: `
 class Greeter {
+    constructor(param: Array<any>) {}
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [{
+                message: "Unexpected any. Specify a different type.",
+                line: 3,
+                column: 30
+            }]
+        },
+        {
+            code: `
+class Greeter {
     message: any;
 }
             `,


### PR DESCRIPTION
This change improves the existing no-explicit-any rule by adding:

- Check for TSUnionTypes
- Check for TSIntersectionTypes
- Check for TypeReferences (Array<*>) and TSArrayType (any[])
- Check for Arguments in class constructors 
- Check for Properties in classes, interfaces and type aliases

This also adds more tests cases