### PR TITLE
Fix: type-annotation-spacing rule doesn't work for class properties (fixes #24)

### DIFF
--- a/docs/rules/type-annotation-spacing.md
+++ b/docs/rules/type-annotation-spacing.md
@@ -1,41 +1,105 @@
 # Enforces spacing around type annotations (type-annotation-spacing)
 
-Type annotations in TypeScript tend to have a very specific format, where the colon appears directly after the identifier or function, followed by a space, followed by the type. For example:
+Spacing around type annotations improves readability of the code. Although the most commonly used style guideline for type annotations in TypeScript prescribes adding a space after the colon, but not before it, it is subjective to the preferences of a project. For example:
 
 ```ts
+// with space after, but not before
 let foo: string = "bar";
 
-function foo(a: string): string {
-    // code
-}
-```
+// with space before and after 
+let foo : string = "bar";
 
-This convention is carried through TypeScript documentation and is the most common convention used for TypeScript code.
+// with space before, but not after
+let foo :string = "bar";
+```
 
 ## Rule Details
 
-This rule aims to enforce specific spacing patterns around type annotations. As such, it will warn when there is a space before the colon or a space is missing after the colon of a type annotation.
+This rule aims to enforce specific spacing patterns around type annotations.
 
-The following patterns are considered warnings:
+## Options 
 
+This rule has an object option:
+- `"before": false` (default) disallows spaces before the colon.
+- `"before": true` requires a space before the colon.
+- `"after": true` (default) requires a space after the colon.
+- `"after": false` disallows spaces after the colon.
+
+### after
+Examples of **incorrect** code for this rule with the default `{ "before": false, "after": true }` options:
 ```ts
 let foo:string = "bar";
+let foo :string = "bar";
+let foo : string = "bar";
 
-function foo(a : string):string {
-    // code
+function foo():string {}
+function foo() :string {}
+function foo() : string {}
+
+class Foo {
+    name:string;
+}
+
+class Foo {
+    name :string;
+}
+
+class Foo {
+    name : string;
 }
 ```
 
-The following patterns are not warnings:
-
-```js
+Examples of **correct** code for this rule with the default `{ "before": false, "after": true }` options:
+```ts
 let foo: string = "bar";
 
-function foo(a: string): string {
-    // code
+function foo(): string {}
+
+class Foo {
+    name: string;
+}
+```
+
+### before
+Examples of **incorrect** code for this rule with `{ "before": true, "after": true }` options:
+```ts
+let foo: string = "bar";
+let foo:string = "bar";
+let foo :string = "bar";
+
+function foo(): string {}
+function foo():string {}
+function foo() :string {}
+
+class Foo {
+    name: string;
+}
+
+class Foo {
+    name:string;
+}
+
+class Foo {
+    name :string;
+}
+```
+
+Examples of **correct** code for this rule with `{ "before": true, "after": true }` options:
+```ts
+let foo : string = "bar";
+
+function foo() : string {}
+
+class Foo {
+    name : string;
 }
 ```
 
 ## When Not To Use It
 
 If you don't want to enforce spacing for your type annotations, you can safely turn this rule off.
+
+## Further Reading
+
+* [TypeScript Type System](https://basarat.gitbooks.io/typescript/docs/types/type-system.html)
+* [Type Inference](https://www.typescriptlang.org/docs/handbook/type-inference.html)

--- a/tests/lib/rules/type-annotation-spacing.js
+++ b/tests/lib/rules/type-annotation-spacing.js
@@ -11,14 +11,12 @@
 let rule = require("../../../lib/rules/type-annotation-spacing"),
     RuleTester = require("eslint").RuleTester;
 
-
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
 let ruleTester = new RuleTester();
 ruleTester.run("type-annotation-spacing", rule, {
-
     valid: [
         {
             code: "let foo: string;",
@@ -31,9 +29,613 @@ ruleTester.run("type-annotation-spacing", rule, {
         {
             code: "function foo(a: string) {}",
             parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    name: string;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    constructor(message: string);
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet(): string { return "hello"; }
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet(name: string): string { return name; }
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet(): string;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet(name: string): string;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet(): string;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet(name: string): string;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "let foo: string;",
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function foo(): string {}",
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function foo(a: string) {}",
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    name: string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    constructor(message: string);
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet(): string { return "hello"; }
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet(name: string): string { return name; }
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet(): string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet(name: string): string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet(): string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet(name: string): string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "let foo: string;",
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function foo(): string {}",
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function foo(a: string) {}",
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    name: string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    constructor(message: string);
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet(): string { return "hello"; }
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet(name: string): string { return name; }
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet(): string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet(name: string): string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet(): string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet(name: string): string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "let foo : string;",
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function foo() : string {}",
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function foo(a : string) {}",
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    name : string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    constructor(message : string);
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet() : string { return "hello"; }
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet(name : string) : string { return name; }
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    name : string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet() : string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet(name : string) : string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    name : string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet() : string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet(name : string) : string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "let foo :string;",
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function foo() :string {}",
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function foo(a :string) {}",
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    name :string;
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    constructor(message :string);
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet() :string { return "hello"; }
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet(name :string) :string { return name; }
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    name :string;
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet() :string;
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet(name :string) :string;
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    name :string;
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet() :string;
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet(name :string) :string;
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "let foo : string;",
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function foo() : string {}",
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "function foo(a : string) {}",
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    name : string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    constructor(message : string);
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet() : string { return "hello"; }
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet(name : string) : string { return name; }
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    name : string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet() : string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    greet(name : string) : string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    name : string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet() : string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    greet(name : string) : string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
         }
     ],
-
     invalid: [
         {
             code: "let foo : string;",
@@ -42,48 +644,1405 @@ ruleTester.run("type-annotation-spacing", rule, {
             errors: [{
                 message: "Unexpected space before the colon.",
                 line: 1,
-                column: 11
+                column: 8
             }]
         },
         {
-            code: "let foo:string;",
+            code: "function foo() : string {}",
             parser: "typescript-eslint-parser",
-            output: "let foo: string;",
+            output: "function foo(): string {}",
             errors: [{
-                message: "Expected a space after the colon.",
+                message: "Unexpected space before the colon.",
                 line: 1,
+                column: 15
+            }]
+        },
+        {
+            code: "function foo(a : string) {}",
+            parser: "typescript-eslint-parser",
+            output: "function foo(a: string) {}",
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 1,
+                column: 15
+            }]
+        },
+        {
+            code: `
+class Foo {
+    name : string;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    name: string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
                 column: 9
             }]
         },
         {
-            code: "function foo():string {}",
+            code: `
+class Foo {
+    constructor(message : string);
+}
+            `,
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    constructor(message: string);
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 24
+            }]
+        },
+        {
+            code: `
+class Foo {
+    greet() : string { return "hello"; }
+}
+            `,
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    greet(): string { return "hello"; }
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 12
+            }]
+        },
+        {
+            code: `
+class Foo {
+    greet(name : string) : string { return name; }
+}
+            `,
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    greet(name: string): string { return name; }
+}
+            `,
+            errors: [
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: `
+interface Foo {
+    name : string;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    name: string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 9
+            }]
+        },
+        {
+            code: `
+interface Foo {
+    greet() : string;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    greet(): string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 12
+            }]
+        },
+        {
+            code: `
+interface Foo {
+    greet(name : string) : string;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    greet(name: string): string;
+}
+            `,
+            errors: [
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: `
+type Foo = {
+    name : string;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    name: string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 9
+            }]
+        },
+        {
+            code: `
+type Foo = {
+    greet() : string;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    greet(): string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 12
+            }]
+        },
+        {
+            code: `
+type Foo = {
+    greet(name : string) : string;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    greet(name: string): string;
+}
+            `,
+            errors: [
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: "let foo : string;",
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser",
+            output: "let foo: string;",
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 1,
+                column: 8
+            }]
+        },
+        {
+            code: "function foo() : string {}",
+            options: [{ after: true }],
             parser: "typescript-eslint-parser",
             output: "function foo(): string {}",
             errors: [{
-                message: "Expected a space after the colon.",
+                message: "Unexpected space before the colon.",
                 line: 1,
-                column: 16
+                column: 15
             }]
         },
         {
-            code: "let foo = function():string {}",
+            code: "function foo(a : string) {}",
+            options: [{ after: true }],
             parser: "typescript-eslint-parser",
-            output: "let foo = function(): string {}",
+            output: "function foo(a: string) {}",
             errors: [{
-                message: "Expected a space after the colon.",
+                message: "Unexpected space before the colon.",
                 line: 1,
-                column: 22
+                column: 15
             }]
         },
         {
-            code: "let foo = ():string => {}",
+            code: `
+class Foo {
+    name : string;
+}
+            `,
+            options: [{ after: true }],
             parser: "typescript-eslint-parser",
-            output: "let foo = (): string => {}",
+            output: `
+class Foo {
+    name: string;
+}
+            `,
             errors: [{
-                message: "Expected a space after the colon.",
-                line: 1,
-                column: 14
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 9
             }]
+        },
+        {
+            code: `
+class Foo {
+    constructor(message : string);
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    constructor(message: string);
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 24
+            }]
+        },
+        {
+            code: `
+class Foo {
+    greet() : string { return "hello"; }
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    greet(): string { return "hello"; }
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 12
+            }]
+        },
+        {
+            code: `
+class Foo {
+    greet(name : string) : string { return name; }
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    greet(name: string): string { return name; }
+}
+            `,
+            errors: [
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: `
+interface Foo {
+    name : string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    name: string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 9
+            }]
+        },
+        {
+            code: `
+interface Foo {
+    greet() : string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    greet(): string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 12
+            }]
+        },
+        {
+            code: `
+interface Foo {
+    greet(name : string) : string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    greet(name: string): string;
+}
+            `,
+            errors: [
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: `
+type Foo = {
+    name : string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    name: string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 9
+            }]
+        },
+        {
+            code: `
+type Foo = {
+    greet() : string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    greet(): string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 12
+            }]
+        },
+        {
+            code: `
+type Foo = {
+    greet(name : string) : string;
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    greet(name: string): string;
+}
+            `,
+            errors: [
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: "let foo : string;",
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: "let foo: string;",
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 1,
+                column: 8
+            }]
+        },
+        {
+            code: "function foo() : string {}",
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: "function foo(): string {}",
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 1,
+                column: 15
+            }]
+        },
+        {
+            code: "function foo(a : string) {}",
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: "function foo(a: string) {}",
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 1,
+                column: 15
+            }]
+        },
+        {
+            code: `
+class Foo {
+    name : string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    name: string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 9
+            }]
+        },
+        {
+            code: `
+class Foo {
+    constructor(message : string);
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    constructor(message: string);
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 24
+            }]
+        },
+        {
+            code: `
+class Foo {
+    greet() : string { return "hello"; }
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    greet(): string { return "hello"; }
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 12
+            }]
+        },
+        {
+            code: `
+class Foo {
+    greet(name : string) : string { return name; }
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    greet(name: string): string { return name; }
+}
+            `,
+            errors: [
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: `
+interface Foo {
+    name : string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    name: string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 9
+            }]
+        },
+        {
+            code: `
+interface Foo {
+    greet() : string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    greet(): string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 12
+            }]
+        },
+        {
+            code: `
+interface Foo {
+    greet(name : string) : string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    greet(name: string): string;
+}
+            `,
+            errors: [
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: `
+type Foo = {
+    name : string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    name: string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 9
+            }]
+        },
+        {
+            code: `
+type Foo = {
+    greet() : string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    greet(): string;
+}
+            `,
+            errors: [{
+                message: "Unexpected space before the colon.",
+                line: 3,
+                column: 12
+            }]
+        },
+        {
+            code: `
+type Foo = {
+    greet(name : string) : string;
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    greet(name: string): string;
+}
+            `,
+            errors: [
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Unexpected space before the colon.",
+                    line: 3,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: "let foo:string;",
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: "let foo : string;",
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 1,
+                    column: 7
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 1,
+                    column: 8
+                }
+            ]
+        },
+        {
+            code: "function foo():string {}",
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: "function foo() : string {}",
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 1,
+                    column: 14
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 1,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: "function foo(a:string) {}",
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: "function foo(a : string) {}",
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 1,
+                    column: 14
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 1,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: `
+class Foo {
+    name:string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    name : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 8
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: `
+class Foo {
+    constructor(message:string);
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    constructor(message : string);
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 23
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 24
+                }
+            ]
+        },
+        {
+            code: `
+class Foo {
+    greet():string { return "hello"; }
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    greet() : string { return "hello"; }
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 11
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 12
+                }
+            ]
+        },
+        {
+            code: `
+class Foo {
+    greet(name:string):string { return name; }
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    greet(name : string) : string { return name; }
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 14
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 22
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 23
+                }
+            ]
+        },
+        {
+            code: `
+interface Foo {
+    name:string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    name : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 8
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: `
+interface Foo {
+    greet():string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    greet() : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 11
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 12
+                }
+            ]
+        },
+        {
+            code: `
+interface Foo {
+    greet(name:string):string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    greet(name : string) : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 14
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 22
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 23
+                }
+            ]
+        },
+        {
+            code: `
+type Foo = {
+    name:string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    name : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 8
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: `
+type Foo = {
+    greet():string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    greet() : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 11
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 12
+                }
+            ]
+        },
+        {
+            code: `
+type Foo = {
+    greet(name:string):string;
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    greet(name : string) : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 14
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 22
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 23
+                }
+            ]
+        },
+        {
+            code: "let foo:string;",
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: "let foo : string;",
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 1,
+                    column: 7
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 1,
+                    column: 8
+                }
+            ]
+        },
+        {
+            code: "function foo():string {}",
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: "function foo() : string {}",
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 1,
+                    column: 14
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 1,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: "function foo(a:string) {}",
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: "function foo(a : string) {}",
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 1,
+                    column: 14
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 1,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: `
+class Foo {
+    name:string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    name : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 8
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: `
+class Foo {
+    constructor(message:string);
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    constructor(message : string);
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 23
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 24
+                }
+            ]
+        },
+        {
+            code: `
+class Foo {
+    greet():string { return "hello"; }
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    greet() : string { return "hello"; }
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 11
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 12
+                }
+            ]
+        },
+        {
+            code: `
+class Foo {
+    greet(name:string):string { return name; }
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+class Foo {
+    greet(name : string) : string { return name; }
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 14
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 22
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 23
+                }
+            ]
+        },
+        {
+            code: `
+interface Foo {
+    name:string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    name : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 8
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: `
+interface Foo {
+    greet():string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    greet() : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 11
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 12
+                }
+            ]
+        },
+        {
+            code: `
+interface Foo {
+    greet(name:string):string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+interface Foo {
+    greet(name : string) : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 14
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 22
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 23
+                }
+            ]
+        },
+        {
+            code: `
+type Foo = {
+    name:string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    name : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 8
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: `
+type Foo = {
+    greet():string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    greet() : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 11
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 12
+                }
+            ]
+        },
+        {
+            code: `
+type Foo = {
+    greet(name:string):string;
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser",
+            output: `
+type Foo = {
+    greet(name : string) : string;
+}
+            `,
+            errors: [
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 14
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 15
+                },
+                {
+                    message: "Expected a space before the colon.",
+                    line: 3,
+                    column: 22
+                },
+                {
+                    message: "Expected a space after the colon.",
+                    line: 3,
+                    column: 23
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
This change improves the existing type-annotation-spacing rule by adding:
- Support for class properties and methods
- Support for interfaces properties and methods
- Add options to control the spacings before and after the colon