### PR TITLE
Fix: adjacent-overload-signatures fails with type (fixes #49)

### DIFF
--- a/docs/rules/adjacent-overload-signatures.md
+++ b/docs/rules/adjacent-overload-signatures.md
@@ -1,6 +1,6 @@
 # Enforces member overloads to be consecutive.
 
-Grouping overloaded members (methods and functions) together can improve readability of the code.
+Grouping overloaded members together can improve readability of the code.
 
 ## Rule Details
 
@@ -36,6 +36,11 @@ class Foo {
   bar(): void {}
   foo(sn: string | number): void {}
 }
+
+export function foo(s: string): void;
+export function foo(n: number): void;
+export function bar(): void;
+export function foo(sn: string | number): void;
 ```
 
 The following patterns are not warnings:
@@ -45,29 +50,34 @@ declare namespace Foo {
     export function foo(s: string): void;
     export function foo(n: number): void;
     export function foo(sn: string | number): void;
-    export function bar(): void;    
+    export function bar(): void;
 }
 
 type Foo = {
   foo(s: string): void;
-  foo(n: number): void;  
+  foo(n: number): void;
   foo(sn: string | number): void;
   bar(): void;
 }
 
 interface Foo {
   foo(s: string): void;
-  foo(n: number): void;  
+  foo(n: number): void;
   foo(sn: string | number): void;
   bar(): void;
 }
 
 class Foo {
   foo(s: string): void;
-  foo(n: number): void;  
+  foo(n: number): void;
   foo(sn: string | number): void {}
   bar(): void {}
 }
+
+export function bar(): void;
+export function foo(s: string): void;
+export function foo(n: number): void;
+export function foo(sn: string | number): void;
 ```
 
 ## When Not To Use It

--- a/lib/rules/adjacent-overload-signatures.js
+++ b/lib/rules/adjacent-overload-signatures.js
@@ -31,8 +31,9 @@ module.exports = {
          */
         function getMemberName(member) {
             switch (member.type) {
+                case "ExportDefaultDeclaration":
                 case "ExportNamedDeclaration": {
-                    return member.declaration.id.name;
+                    return getMemberName(member.declaration);
                 }
                 case "DeclareFunction":
                 case "FunctionDeclaration":
@@ -45,6 +46,9 @@ module.exports = {
                 }
                 case "TSCallSignature": {
                     return "call";
+                }
+                case "TSConstructSignature": {
+                    return "new";
                 }
                 case "MethodDefinition": {
                     return member.key.name || member.key.value;
@@ -65,11 +69,14 @@ module.exports = {
             const members = node.body || node.members;
 
             if (members) {
+                let name;
+                let index;
+                let lastName;
                 const seen = [];
-                let index, name, lastName;
 
                 members.forEach(member => {
                     name = getMemberName(member);
+
                     index = seen.indexOf(name);
                     if (index > -1 && lastName !== name) {
                         context.report({

--- a/tests/lib/rules/adjacent-overload-signatures.js
+++ b/tests/lib/rules/adjacent-overload-signatures.js
@@ -22,8 +22,69 @@ ruleTester.run("adjacent-overload-signatures", rule, {
     valid: [
         {
             code: `
-function foo(s: string) {}
-function foo(n: number) {}
+export const foo = "a", bar = "b";
+export interface Foo {}
+export class Foo {}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+export interface Foo {}
+export const foo = "a", bar = "b";
+export class Foo {}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+const foo = "a", bar = "b";
+interface Foo {}
+class Foo {}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {}
+const foo = "a", bar = "b";
+class Foo {}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+export class Foo {}
+export class Bar {}
+
+export type FooBar = Foo | Bar;
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+export interface Foo {}
+export class Foo {}
+export class Bar {}
+
+export type FooBar = Foo | Bar;
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+export function foo(s: string);
+export function foo(n: number);
+export function foo(sn: string | number) {}
+export function bar(): void {}
+export function baz(): void {}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+function foo(s: string);
+function foo(n: number);
 function foo(sn: string | number) {}
 function bar(): void {}
 function baz(): void {}
@@ -140,6 +201,17 @@ interface Foo {
         },
         {
             code: `
+interface Foo {
+    new(s: string);
+    new(n: number);
+    new(sn: string | number);
+    foo(): void;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
 class Foo {
     constructor(s: string);
     constructor(n: number);
@@ -191,10 +263,61 @@ class Foo {
     invalid: [
         {
             code: `
-function foo(s: string) {}
-function foo(n: number) {}
+export function foo(s: string);
+export function foo(n: number);
+export function bar(): void {}
+export function baz(): void {}
+export function foo(sn: string | number) {}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "All 'foo' signatures should be adjacent",
+                    line: 6,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: `
+export function foo(s: string);
+export function foo(n: number);
+export type bar = number;
+export type baz = number | string;
+export function foo(sn: string | number) {}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "All 'foo' signatures should be adjacent",
+                    line: 6,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: `
+function foo(s: string);
+function foo(n: number);
 function bar(): void {}
 function baz(): void {}
+function foo(sn: string | number) {}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "All 'foo' signatures should be adjacent",
+                    line: 6,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: `
+function foo(s: string);
+function foo(n: number);
+type bar = number;
+type baz = number | string;
 function foo(sn: string | number) {}
             `,
             parser: "typescript-eslint-parser",
@@ -220,6 +343,43 @@ function foo(sn: string | number) {}
                     message: "All 'foo' signatures should be adjacent",
                     line: 6,
                     column: 1
+                }
+            ]
+        },
+        {
+            code: `
+function foo(s: string) {}
+function foo(n: number) {}
+class Bar {}
+function foo(sn: string | number) {}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "All 'foo' signatures should be adjacent",
+                    line: 5,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: `
+function foo(s: string) {}
+function foo(n: number) {}
+function foo(sn: string | number) {}
+class Bar {
+    foo(s: string);
+    foo(n: number);
+    name: string;
+    foo(sn: string | number) { }
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "All 'foo' signatures should be adjacent",
+                    line: 9,
+                    column: 5
                 }
             ]
         },
@@ -263,7 +423,7 @@ declare module "Foo" {
     export function foo(s: string): void;
     export function foo(n: number): void;
     export function bar(): void;
-    export function baz(): void;    
+    export function baz(): void;
     export function foo(sn: string | number): void;
 }
             `,
@@ -300,7 +460,7 @@ declare module "Foo" {
         {
             code: `
 declare namespace Foo {
-    export function foo(s: string): void;    
+    export function foo(s: string): void;
     export function foo(n: number): void;
     export function bar(): void;
     export function baz(): void;
@@ -510,6 +670,49 @@ interface Foo {
                     message: "All 'baz' signatures should be adjacent",
                     line: 8,
                     column: 9
+                }
+            ]
+        },
+        {
+            code: `
+interface Foo {
+    new(s: string);
+    new(n: number);
+    foo(): void;
+    bar(): void;
+    new(sn: string | number);
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "All 'new' signatures should be adjacent",
+                    line: 7,
+                    column: 5
+                }
+            ]
+        },
+        {
+            code: `
+interface Foo {
+    new(s: string);
+    foo(): void;
+    new(n: number);
+    bar(): void;
+    new(sn: string | number);
+}
+            `,
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "All 'new' signatures should be adjacent",
+                    line: 5,
+                    column: 5
+                },
+                {
+                    message: "All 'new' signatures should be adjacent",
+                    line: 7,
+                    column: 5
                 }
             ]
         },


### PR DESCRIPTION
Fixes #49, now export members are handled by recursively calling getMemberName
Also added some missing expressions (TSConstructSignature)