### PR TITLE
Fix: fixes incorrectly marked function call as misplaced (fixes #63)

### DIFF
--- a/lib/rules/adjacent-overload-signatures.js
+++ b/lib/rules/adjacent-overload-signatures.js
@@ -29,10 +29,16 @@ module.exports = {
          * @private
          */
         function getMemberName(member) {
+            if (!member) return null;
+
             switch (member.type) {
                 case "ExportDefaultDeclaration":
                 case "ExportNamedDeclaration": {
-                    return getMemberName(member.declaration);
+                    // export statements (e.g. export { a };)
+                    // have no declarations, so ignore them
+                    return member.declaration
+                        ? getMemberName(member.declaration)
+                        : null;
                 }
                 case "DeclareFunction":
                 case "FunctionDeclaration":

--- a/lib/rules/adjacent-overload-signatures.js
+++ b/lib/rules/adjacent-overload-signatures.js
@@ -84,7 +84,7 @@ module.exports = {
                             node: member,
                             message: `All '${name}' signatures should be adjacent`
                         });
-                    } else if (index === -1) {
+                    } else if (name && index === -1) {
                         seen.push(name);
                     }
 

--- a/tests/lib/rules/adjacent-overload-signatures.js
+++ b/tests/lib/rules/adjacent-overload-signatures.js
@@ -21,6 +21,17 @@ ruleTester.run("adjacent-overload-signatures", rule, {
     valid: [
         {
             code: `
+import { connect } from 'react-redux';
+export interface ErrorMessageModel { message: string; }
+function mapStateToProps() { }
+function mapDispatchToProps() { }
+export default connect(mapStateToProps, mapDispatchToProps)(ErrorMessage);
+            `,
+            parserOptions: { sourceType: "module" },
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
 export const foo = "a", bar = "b";
 export interface Foo {}
 export class Foo {}

--- a/tests/lib/rules/adjacent-overload-signatures.js
+++ b/tests/lib/rules/adjacent-overload-signatures.js
@@ -21,6 +21,16 @@ ruleTester.run("adjacent-overload-signatures", rule, {
     valid: [
         {
             code: `
+function error(a: string);
+function error(b: number);
+function error(ab: string|number){ }
+export { error };
+            `,
+            parserOptions: { sourceType: "module" },
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
 import { connect } from 'react-redux';
 export interface ErrorMessageModel { message: string; }
 function mapStateToProps() { }


### PR DESCRIPTION
Missed a validation that was required to prevent null values to be stored in the seen array