### PR TITLE
New: Add member-naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ Then configure the rules you want to use under the rules section.
 * [`typescript/class-name-casing`](./docs/rules/adjacent-overload-signatures.md) - enforces PascalCased class and interface names. (`class-name` from TSLint)
 * [`typescript/member-delimiter-style`](./docs/rules/member-delimiter-style.md) - enforces a member delimiter style in interfaces and type literals.
 * [`typescript/no-empty-interface`](./docs/rules/no-empty-interface.md) - disallows the declaration of empty interfaces. (`no-empty-interface` from TSLint)
+* [`typescript/member-naming`](./docs/rules/member-naming.md) - enforces naming conventions for class members by visibility

--- a/docs/rules/member-naming.md
+++ b/docs/rules/member-naming.md
@@ -1,0 +1,39 @@
+# Enforces naming conventions for class members by visibility.
+
+It can be helpful to enforce naming conventions for `private` (and sometimes `protected`) members of an object. For example, prefixing private properties with a `_` allows them to be easily discerned when being inspected by tools that do not have knowledge of TypeScript (such as most debuggers).
+
+## Rule Details
+
+This rule allows you to enforce conventions for class property names by their visibility.  By default, it enforces nothing.
+
+## Options
+
+You can specify a regular expression to test the names of properties for each visibility level: `public`, `protected`, `private`.
+
+Examples of **correct** code with `{ "private": "^_" }` specified:
+
+```ts
+class HappyClass {
+    private _foo: string;
+    private _bar = 123;
+    private _fizz() {}
+}
+```
+
+Examples of **incorrect** code with `{ "private": "^_" }` specified:
+
+```ts
+class SadClass {
+    private foo: string;
+    private bar = 123;
+    private fizz() {}
+}
+```
+
+## When Not To Use It
+
+If you do not want to enforce per-visibility naming rules for member properties.
+
+## Further Reading
+
+* ESLint's [`camelcase` rule](https://eslint.org/docs/rules/camelcase)

--- a/lib/rules/member-naming.js
+++ b/lib/rules/member-naming.js
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Enforces naming conventions for class members by visibility.
+ * @author Ian MacLeod
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "Enforces naming conventions for class members by visibility.",
+            category: "TypeScript"
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    public: { type: "string" },
+                    protected: { type: "string" },
+                    private: { type: "string" }
+                },
+                additionalProperties: false
+            }
+        ]
+    },
+
+    create(context) {
+        const config = context.options[0] || {};
+        const conventions = {};
+
+        for (const accessibility of Object.getOwnPropertyNames(config)) {
+            conventions[accessibility] = new RegExp(config[accessibility]);
+        }
+
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+
+        /**
+         * Check that the property name matches the convention for its
+         * accessibility.
+         * @param {ASTNode} node the named node to evaluate.
+         * @returns {void}
+         * @private
+         */
+        function validateName(node) {
+            const name = node.key.name;
+            const accessibility = node.accessibility || "public";
+            const convention = conventions[accessibility];
+
+            if (!convention || convention.test(name)) return;
+
+            context.report({
+                node: node.key,
+                message:
+                    "{{accessibility}} property {{name}} should match {{convention}}",
+                data: { accessibility, name, convention }
+            });
+        }
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        return {
+            MethodDefinition: validateName,
+            ClassProperty: validateName
+        };
+    }
+};

--- a/tests/lib/rules/member-naming.js
+++ b/tests/lib/rules/member-naming.js
@@ -1,0 +1,275 @@
+/**
+ * @fileoverview Enforces naming conventions for class members by visibility.
+ * @author Ian MacLeod
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/member-naming"),
+    RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("member-naming", rule, {
+    valid: [
+        {
+            code: `class Class { _fooBar() {} }`,
+            parser: "typescript-eslint-parser",
+            options: [{ public: "^_" }]
+        },
+        {
+            code: `class Class { public _fooBar() {} }`,
+            parser: "typescript-eslint-parser",
+            options: [{ public: "^_" }]
+        },
+        {
+            code: `class Class { protected _fooBar() {} }`,
+            parser: "typescript-eslint-parser",
+            options: [{ protected: "^_" }]
+        },
+        {
+            code: `class Class { private _fooBar() {} }`,
+            parser: "typescript-eslint-parser",
+            options: [{ private: "^_" }]
+        },
+        {
+            code: `class Class { protected fooBar() {} }`,
+            parser: "typescript-eslint-parser",
+            options: [{ private: "^_" }]
+        },
+        {
+            code: `
+class Class {
+    pubOne() {}
+    public pubTwo() {}
+    protected protThree() {}
+    private privFour() {}
+}
+            `,
+            parser: "typescript-eslint-parser",
+            options: [
+                {
+                    public: "^pub[A-Z]",
+                    protected: "^prot[A-Z]",
+                    private: "^priv[A-Z]"
+                }
+            ]
+        },
+        {
+            code: `
+class Class {
+    pubOne: string;
+    public pubTwo: string;
+    protected protThree: string;
+    private privFour: string;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            options: [
+                {
+                    public: "^pub[A-Z]",
+                    protected: "^prot[A-Z]",
+                    private: "^priv[A-Z]"
+                }
+            ]
+        },
+        {
+            code: `
+class Class {
+    pubOne = true;
+    public pubTwo = true;
+    protected protThree = true;
+    private privFour = true;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            options: [
+                {
+                    public: "^pub[A-Z]",
+                    protected: "^prot[A-Z]",
+                    private: "^priv[A-Z]"
+                }
+            ]
+        }
+    ],
+    invalid: [
+        {
+            code: `class Class { fooBar() {} }`,
+            parser: "typescript-eslint-parser",
+            options: [{ public: "^_" }],
+            errors: [
+                {
+                    message: "public property fooBar should match /^_/",
+                    line: 1,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: `class Class { public fooBar() {} }`,
+            parser: "typescript-eslint-parser",
+            options: [{ public: "^_" }],
+            errors: [
+                {
+                    message: "public property fooBar should match /^_/",
+                    line: 1,
+                    column: 22
+                }
+            ]
+        },
+        {
+            code: `class Class { protected fooBar() {} }`,
+            parser: "typescript-eslint-parser",
+            options: [{ protected: "^_" }],
+            errors: [
+                {
+                    message: "protected property fooBar should match /^_/",
+                    line: 1,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: `class Class { private fooBar() {} }`,
+            parser: "typescript-eslint-parser",
+            options: [{ private: "^_" }],
+            errors: [
+                {
+                    message: "private property fooBar should match /^_/",
+                    line: 1,
+                    column: 23
+                }
+            ]
+        },
+        {
+            code: `
+class Class {
+    one() {}
+    public two() {}
+    protected three() {}
+    private four() {}
+}
+            `,
+            parser: "typescript-eslint-parser",
+            options: [
+                {
+                    public: "^pub[A-Z]",
+                    protected: "^prot[A-Z]",
+                    private: "^priv[A-Z]"
+                }
+            ],
+            errors: [
+                {
+                    message: "public property one should match /^pub[A-Z]/",
+                    line: 3,
+                    column: 5
+                },
+                {
+                    message: "public property two should match /^pub[A-Z]/",
+                    line: 4,
+                    column: 12
+                },
+                {
+                    message:
+                        "protected property three should match /^prot[A-Z]/",
+                    line: 5,
+                    column: 15
+                },
+                {
+                    message: "private property four should match /^priv[A-Z]/",
+                    line: 6,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: `
+class Class {
+    one: string;
+    public two: string;
+    protected three: string;
+    private four: string;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            options: [
+                {
+                    public: "^pub[A-Z]",
+                    protected: "^prot[A-Z]",
+                    private: "^priv[A-Z]"
+                }
+            ],
+            errors: [
+                {
+                    message: "public property one should match /^pub[A-Z]/",
+                    line: 3,
+                    column: 5
+                },
+                {
+                    message: "public property two should match /^pub[A-Z]/",
+                    line: 4,
+                    column: 12
+                },
+                {
+                    message:
+                        "protected property three should match /^prot[A-Z]/",
+                    line: 5,
+                    column: 15
+                },
+                {
+                    message: "private property four should match /^priv[A-Z]/",
+                    line: 6,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: `
+class Class {
+    one = true;
+    public two = true;
+    protected three = true;
+    private four = true;
+}
+            `,
+            parser: "typescript-eslint-parser",
+            options: [
+                {
+                    public: "^pub[A-Z]",
+                    protected: "^prot[A-Z]",
+                    private: "^priv[A-Z]"
+                }
+            ],
+            errors: [
+                {
+                    message: "public property one should match /^pub[A-Z]/",
+                    line: 3,
+                    column: 5
+                },
+                {
+                    message: "public property two should match /^pub[A-Z]/",
+                    line: 4,
+                    column: 12
+                },
+                {
+                    message:
+                        "protected property three should match /^prot[A-Z]/",
+                    line: 5,
+                    column: 15
+                },
+                {
+                    message: "private property four should match /^priv[A-Z]/",
+                    line: 6,
+                    column: 13
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
A new rule to enforce naming conventions for class members by visibility.

It can be helpful to enforce naming conventions for `private` (and sometimes `protected`) members of an object. For example, prefixing private properties with a `_` allows them to be easily discerned when being inspected by tools that do not have knowledge of TypeScript (such as most debuggers).