### PR TITLE
New: add no-array-constructor rule

### DIFF
--- a/docs/rules/no-array-constructor.md
+++ b/docs/rules/no-array-constructor.md
@@ -1,0 +1,34 @@
+# disallow generic `Array` constructors (no-array-constructor)
+
+Use of the `Array` constructor to construct a new array is generally discouraged in favor of array literal notation because of the single-argument pitfall and because the `Array` global may be redefined. Two exceptions are when the Array constructor is used to intentionally create sparse arrays of a specified size by giving the constructor a single numeric argument, or when using TypeScript  type parameters to specify the type of the items of the array (`new Array<Foo>()`).
+
+## Rule Details
+
+This rule disallows `Array` constructors.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+/*eslint no-array-constructor: "error"*/
+
+Array(0, 1, 2)
+new Array(0, 1, 2)
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+/*eslint no-array-constructor: "error"*/
+
+Array<number>(0, 1, 2)
+new Array<Foo>(x, y, z)
+
+Array(500)
+new Array(someOtherArray.length)
+```
+
+## When Not To Use It
+
+This rule enforces a nearly universal stylistic concern. That being said, this rule may be disabled if the constructor style is preferred.
+
+<sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/7685fed33b15763ee3cf7dbe1facfc5ba85173f3/docs/rules/no-array-constructor.md)</sup>

--- a/docs/rules/no-array-constructor.md
+++ b/docs/rules/no-array-constructor.md
@@ -1,6 +1,6 @@
-# disallow generic `Array` constructors (no-array-constructor)
+# Disallow generic `Array` constructors (no-array-constructor)
 
-Use of the `Array` constructor to construct a new array is generally discouraged in favor of array literal notation because of the single-argument pitfall and because the `Array` global may be redefined. Two exceptions are when the Array constructor is used to intentionally create sparse arrays of a specified size by giving the constructor a single numeric argument, or when using TypeScript  type parameters to specify the type of the items of the array (`new Array<Foo>()`).
+Use of the `Array` constructor to construct a new array is generally discouraged in favor of array literal notation because of the single-argument pitfall and because the `Array` global may be redefined. Two exceptions are when the Array constructor is used to intentionally create sparse arrays of a specified size by giving the constructor a single numeric argument, or when using TypeScript type parameters to specify the type of the items of the array (`new Array<Foo>()`).
 
 ## Rule Details
 

--- a/lib/rules/no-array-constructor.js
+++ b/lib/rules/no-array-constructor.js
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview disallow generic `Array` constructors
+ * @author Jed Fox
+ * @author Matt DuVall <http://www.mattduvall.com/>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow generic `Array` constructors",
+            category: "Stylistic Issues",
+            recommended: false
+        },
+        fixable: "code",
+        schema: []
+    },
+
+    create(context) {
+        /**
+         * Disallow construction of dense arrays using the Array constructor
+         * @param {ASTNode} node node to evaluate
+         * @returns {void}
+         * @private
+         */
+        function check(node) {
+            if (
+                node.arguments.length !== 1 &&
+                node.callee.type === "Identifier" &&
+                node.callee.name === "Array" &&
+                !node.typeParameters
+            ) {
+                context.report({
+                    node,
+                    message: "The array literal notation [] is preferrable.",
+                    fix(fixer) {
+                        if (node.arguments.length === 0) {
+                            return fixer.replaceText(node, "[]");
+                        }
+                        const fullText = context.getSourceCode().getText(node);
+                        const preambleLength =
+                            node.callee.range[1] - node.range[0];
+
+                        return fixer.replaceText(
+                            node,
+                            `[${fullText.slice(preambleLength + 1, -1)}]`
+                        );
+                    }
+                });
+            }
+        }
+
+        return {
+            CallExpression: check,
+            NewExpression: check
+        };
+    }
+};

--- a/lib/rules/no-array-constructor.js
+++ b/lib/rules/no-array-constructor.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview disallow generic `Array` constructors
+ * @fileoverview Disallow generic `Array` constructors
  * @author Jed Fox
  * @author Matt DuVall <http://www.mattduvall.com/>
  */
@@ -12,7 +12,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "disallow generic `Array` constructors",
+            description: "Disallow generic `Array` constructors",
             category: "Stylistic Issues",
             recommended: false
         },

--- a/tests/lib/rules/no-array-constructor.js
+++ b/tests/lib/rules/no-array-constructor.js
@@ -1,0 +1,93 @@
+/**
+ * @fileoverview disallow generic `Array` constructors
+ * @author Jed Fox
+ * @author Matt DuVall <http://www.mattduvall.com/>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-array-constructor"),
+    RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+    parser: "typescript-eslint-parser"
+});
+
+const message = "The array literal notation [] is preferrable.";
+
+ruleTester.run("no-array-constructor", rule, {
+    valid: [
+        "new Array(x)",
+        "Array(x)",
+        "new Array(9)",
+        "Array(9)",
+        "new foo.Array()",
+        "foo.Array()",
+        "new Array.foo",
+        "Array.foo()",
+
+        // TypeScript
+        "new Array<Foo>(1, 2, 3)",
+        "new Array<Foo>()",
+        "Array<Foo>(1, 2, 3)",
+        "Array<Foo>()"
+    ],
+
+    invalid: [
+        {
+            code: "new Array()",
+            output: "[]",
+            errors: [{ message, type: "NewExpression" }]
+        },
+        {
+            code: "Array()",
+            output: "[]",
+            errors: [{ message, type: "CallExpression" }]
+        },
+        {
+            code: "new Array",
+            output: "[]",
+            errors: [{ message, type: "NewExpression" }]
+        },
+        {
+            code: "new Array(x, y)",
+            output: "[x, y]",
+            errors: [{ message, type: "NewExpression" }]
+        },
+        {
+            code: "Array(x, y)",
+            output: "[x, y]",
+            errors: [{ message, type: "CallExpression" }]
+        },
+        {
+            code: "new Array(0, 1, 2)",
+            output: "[0, 1, 2]",
+            errors: [{ message, type: "NewExpression" }]
+        },
+        {
+            code: "Array(0, 1, 2)",
+            output: "[0, 1, 2]",
+            errors: [{ message, type: "CallExpression" }]
+        },
+        {
+            code: `new Array(
+                0,
+                1,
+                2
+            )`,
+            output: `[
+                0,
+                1,
+                2
+            ]`,
+            errors: [{ message, type: "NewExpression" }]
+        }
+    ]
+});


### PR DESCRIPTION
Copied from ESLint core, except it allows `new Array<Foo>()` annotations.