### PR TITLE
Fix: fixes an issue with the way type annotations are handled (fixes #69)

### DIFF
--- a/lib/rules/type-annotation-spacing.js
+++ b/lib/rules/type-annotation-spacing.js
@@ -75,7 +75,7 @@ module.exports = {
          * @private
          */
         function checkTypeAnnotationSpacing(typeAnnotation) {
-            const nextToken = typeAnnotation.typeAnnotation || typeAnnotation;
+            const nextToken = typeAnnotation;
             const punctuatorToken = sourceCode.getTokenBefore(nextToken);
             const previousToken = sourceCode.getTokenBefore(punctuatorToken);
 
@@ -140,7 +140,9 @@ module.exports = {
          */
         function checkFunctionReturnTypeSpacing(node) {
             if (node.returnType) {
-                checkTypeAnnotationSpacing(node.returnType);
+                checkTypeAnnotationSpacing(
+                    node.returnType.typeAnnotation || node.returnType
+                );
             }
         }
 
@@ -150,20 +152,17 @@ module.exports = {
         return {
             Identifier(node) {
                 if (node.typeAnnotation) {
-                    checkTypeAnnotationSpacing(node.typeAnnotation);
+                    checkTypeAnnotationSpacing(
+                        node.typeAnnotation.typeAnnotation ||
+                            node.typeAnnotation
+                    );
                 }
             },
-
             TypeAnnotation(node) {
-                if (
-                    node.typeAnnotation &&
-                    node.typeAnnotation.type !== "TSFunctionType" &&
-                    node.parent.type !== "TSAsExpression"
-                ) {
+                if (node.parent.type !== "TSAsExpression") {
                     checkTypeAnnotationSpacing(node.typeAnnotation);
                 }
             },
-
             FunctionDeclaration: checkFunctionReturnTypeSpacing,
             FunctionExpression: checkFunctionReturnTypeSpacing,
             ArrowFunctionExpression: checkFunctionReturnTypeSpacing

--- a/tests/lib/rules/type-annotation-spacing.js
+++ b/tests/lib/rules/type-annotation-spacing.js
@@ -28,7 +28,7 @@ ruleTester.run("type-annotation-spacing", rule, {
             parser: "typescript-eslint-parser"
         },
         {
-            code: "function foo(): string {}",
+            code: "function foo(): void {}",
             parser: "typescript-eslint-parser"
         },
         {
@@ -87,6 +87,14 @@ interface Foo {
             code: `
 interface Foo {
     greet(name: string): string;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    thing: { [key in string]: number };
 }
             `,
             parser: "typescript-eslint-parser"
@@ -478,7 +486,7 @@ type Foo = {
         {
             code: `
 type Foo = {
-    greet: (name : string) => string;
+    greet : (name : string) => string;
 }
             `,
             options: [{ after: true, before: true }],
@@ -597,7 +605,7 @@ type Foo = {
         {
             code: `
 type Foo = {
-    greet: (name :string) =>string;
+    greet :(name :string) =>string;
 }
             `,
             options: [{ after: false, before: true }],
@@ -716,7 +724,7 @@ type Foo = {
         {
             code: `
 type Foo = {
-    greet: (name : string) => string;
+    greet : (name : string) => string;
 }
             `,
             options: [{ before: true }],
@@ -919,7 +927,7 @@ type Foo = {
         {
             code: `
 type Foo = {
-    greet: (name : string)=>string;
+    greet : (name : string)=>string;
 }
             `,
             options: [
@@ -954,7 +962,7 @@ type Foo = {
         {
             code: `
 type Foo = {
-    greet: (name : string) => string;
+    greet : (name : string) => string;
 }
             `,
             options: [
@@ -997,7 +1005,7 @@ type Foo = {
         {
             code: `
 type Foo = {
-    greet: (name : string) =>string;
+    greet : (name : string) =>string;
 }
             `,
             options: [
@@ -1015,6 +1023,157 @@ type Foo = {
                     }
                 }
             ],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    thing: { [key in string]: number };
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    thing: { [key in string]: number };
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    thing : { [key in string] : number };
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    thing :{ [key in string] :number };
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo {
+    thing : { [key in string] : number };
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    thing: { [key in string]: number };
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    thing: { [key in string]: number };
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    thing: { [key in string]: number };
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    thing : { [key in string] : number };
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    thing :{ [key in string] :number };
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+type Foo = {
+    thing : { [key in string] : number };
+}
+            `,
+            options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet: (name: string) => void = {}
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet: (name: string) => void = {}
+}
+            `,
+            options: [{ after: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet: (name: string)=> void = {}
+}
+            `,
+            options: [{ after: true, before: false }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet : (name : string) => void = {}
+}
+            `,
+            options: [{ after: true, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet :(name :string) =>void = {}
+}
+            `,
+            options: [{ after: false, before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+class Foo {
+    greet : (name : string) => void = {}
+}
+            `,
+            options: [{ before: true }],
             parser: "typescript-eslint-parser"
         }
     ],
@@ -2413,10 +2572,15 @@ type Foo = {
             options: [{ after: true, before: true }],
             output: `
 type Foo = {
-    greet: (name : string) => string;
+    greet : (name : string) => string;
 }
             `,
             errors: [
+                {
+                    message: "Expected a space before the ':'",
+                    line: 3,
+                    column: 10
+                },
                 {
                     message: "Expected a space before the ':'",
                     line: 3,
@@ -2432,21 +2596,21 @@ type Foo = {
         {
             code: `
 type Foo = {
-    greet: (name : string)=> string;
+    greet : (name : string)=> string;
 }
             `,
             parser: "typescript-eslint-parser",
             options: [{ after: true, before: true }],
             output: `
 type Foo = {
-    greet: (name : string) => string;
+    greet : (name : string) => string;
 }
             `,
             errors: [
                 {
                     message: "Expected a space before the '=>'",
                     line: 3,
-                    column: 27
+                    column: 28
                 }
             ]
         },
@@ -2835,10 +2999,15 @@ type Foo = {
             options: [{ before: true }],
             output: `
 type Foo = {
-    greet: (name : string) => string;
+    greet : (name : string) => string;
 }
             `,
             errors: [
+                {
+                    message: "Expected a space before the ':'",
+                    line: 3,
+                    column: 10
+                },
                 {
                     message: "Expected a space before the ':'",
                     line: 3,
@@ -2854,21 +3023,21 @@ type Foo = {
         {
             code: `
 type Foo = {
-    greet: (name : string)=> string;
+    greet : (name : string)=> string;
 }
             `,
             parser: "typescript-eslint-parser",
             options: [{ before: true }],
             output: `
 type Foo = {
-    greet: (name : string) => string;
+    greet : (name : string) => string;
 }
             `,
             errors: [
                 {
                     message: "Expected a space before the '=>'",
                     line: 3,
-                    column: 27
+                    column: 28
                 }
             ]
         },
@@ -3321,7 +3490,7 @@ type Foo = {
         {
             code: `
 type Foo = {
-    greet: (name:string)=>string;
+    greet : (name:string)=>string;
 }
             `,
             options: [
@@ -3334,19 +3503,19 @@ type Foo = {
             parser: "typescript-eslint-parser",
             output: `
 type Foo = {
-    greet: (name : string)=>string;
+    greet : (name : string)=>string;
 }
             `,
             errors: [
                 {
                     message: "Expected a space after the ':'",
                     line: 3,
-                    column: 17
+                    column: 18
                 },
                 {
                     message: "Expected a space before the ':'",
                     line: 3,
-                    column: 17
+                    column: 18
                 }
             ]
         },
@@ -3396,7 +3565,7 @@ type Foo = {
         {
             code: `
 type Foo = {
-    greet: (name:string)=>string;
+    greet : (name:string)=>string;
 }
             `,
             options: [
@@ -3418,29 +3587,29 @@ type Foo = {
             parser: "typescript-eslint-parser",
             output: `
 type Foo = {
-    greet: (name : string) => string;
+    greet : (name : string) => string;
 }
             `,
             errors: [
                 {
                     message: "Expected a space after the ':'",
                     line: 3,
-                    column: 17
+                    column: 18
                 },
                 {
                     message: "Expected a space before the ':'",
                     line: 3,
-                    column: 17
+                    column: 18
                 },
                 {
                     message: "Expected a space after the '=>'",
                     line: 3,
-                    column: 25
+                    column: 26
                 },
                 {
                     message: "Expected a space before the '=>'",
                     line: 3,
-                    column: 25
+                    column: 26
                 }
             ]
         }


### PR DESCRIPTION
Fixes an issue detected when using typescript-eslint-parser 8.0.0, but the change is backwards compatible with 7.0.0 (tried both). It also fixes an issue in 7.0.0 that will let class/interfaces/types properties go undetected.