### PR TITLE
Add `eslint-docs` to keep rule descriptions consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Then configure the rules you want to use under the rules section.
 * [`typescript/explicit-member-accessibility`](./docs/rules/explicit-member-accessibility.md) — Require explicit accessibility modifiers on class properties and methods (`member-access` from TSLint)
 * [`typescript/interface-name-prefix`](./docs/rules/interface-name-prefix.md) — Require that interface names be prefixed with `I` (`interface-name` from TSLint)
 * [`typescript/member-delimiter-style`](./docs/rules/member-delimiter-style.md) — Require a specific member delimiter style for interfaces and type literals
-* [`typescript/member-naming`](./docs/rules/member-naming.md) — enforces naming conventions for class members by visibility
+* [`typescript/member-naming`](./docs/rules/member-naming.md) — Enforces naming conventions for class members by visibility.
 * [`typescript/member-ordering`](./docs/rules/member-ordering.md) — Require a consistent member declaration order (`member-ordering` from TSLint)
 * [`typescript/no-angle-bracket-type-assertion`](./docs/rules/no-angle-bracket-type-assertion.md) — Enforces the use of `as Type` assertions instead of `<Type>` assertions (`no-angle-bracket-type-assertion` from TSLint)
 * [`typescript/no-empty-interface`](./docs/rules/no-empty-interface.md) — Disallow the declaration of empty interfaces (`no-empty-interface` from TSLint)

--- a/README.md
+++ b/README.md
@@ -49,20 +49,23 @@ Then configure the rules you want to use under the rules section.
 
 ## Supported Rules
 
-* [`typescript/adjacent-overload-signatures`](./docs/rules/adjacent-overload-signatures.md) — enforces member overloads to be consecutive.
-* [`typescript/class-name-casing`](./docs/rules/adjacent-overload-signatures.md) - enforces PascalCased class and interface names. (`class-name` from TSLint)
-* [`typescript/explicit-member-accessibility`](./docs/rules/explicit-member-accessibility.md) — enforces accessibility modifiers on class properties and methods. (`member-access` from TSLint)
-* [`typescript/interface-name-prefix`](./docs/rules/interface-name-prefix.md) — enforces interface names are prefixed. (`interface-name` from TSLint)
-* [`typescript/member-delimiter-style`](./docs/rules/member-delimiter-style.md) - enforces a member delimiter style in interfaces and type literals.
-* [`typescript/member-ordering`](./docs/rules/member-ordering.md) — enforces a standard member declaration order. (`member-ordering` from TSLint)
-* [`typescript/no-angle-bracket-type-assertion`](./docs/rules/no-angle-bracket-type-assertion.md) — enforces the use of `as Type` assertions instead of `<Type>` assertions. (`no-angle-bracket-type-assertion` from TSLint)
-* [`typescript/no-empty-interface`](./docs/rules/no-empty-interface.md) - disallows the declaration of empty interfaces. (`no-empty-interface` from TSLint)
-* [`typescript/no-explicit-any`](./docs/rules/no-explicit-any.md) — enforces the `any` type is not used. (`no-any` from TSLint)
-* [`typescript/no-namespace`](./docs/rules/no-namespace.md) — disallows the use of custom TypeScript modules and namespaces.
-* [`typescript/no-parameter-properties`](./docs/rules/no-parameter-properties.md) - disallows parameter properties in class constructors. (`no-parameter-properties` from TSLint)
-* [`typescript/no-triple-slash-reference`](./docs/rules/no-triple-slash-reference.md) — enforces `/// <reference />` is not used. (`no-reference` from TSLint)
-* [`typescript/no-type-alias`](./docs/rules/no-type-alias.md) — disallows the use of type aliases. (`interface-over-type-literal` from TSLint)
-* [`typescript/no-unused-vars`](./docs/rules/no-unused-vars.md) — prevents TypeScript-specific constructs from being erroneously flagged as unused
-* [`typescript/no-use-before-define`](./docs/rules/no-use-before-define.md) — disallows the use of variables before they are defined.
-* [`typescript/prefer-namespace-keyword`](./docs/rules/prefer-namespace-keyword.md) — enforces the use of the keyword `namespace` over `module` to declare custom TypeScript modules. (`no-internal-module` from TSLint)
-* [`typescript/type-annotation-spacing`](./docs/rules/type-annotation-spacing.md) — enforces one space after the colon and zero spaces before the colon of a type annotation.
+<!-- Please run `npm run docs` to update this section -->
+<!-- begin rule list -->
+* [`typescript/adjacent-overload-signatures`](./docs/rules/adjacent-overload-signatures.md) — Require that member overloads be consecutive
+* [`typescript/class-name-casing`](./docs/rules/class-name-casing.md) — Require PascalCased class and interface names (`class-name` from TSLint)
+* [`typescript/explicit-member-accessibility`](./docs/rules/explicit-member-accessibility.md) — Require explicit accessibility modifiers on class properties and methods (`member-access` from TSLint)
+* [`typescript/interface-name-prefix`](./docs/rules/interface-name-prefix.md) — Require that interface names be prefixed with `I` (`interface-name` from TSLint)
+* [`typescript/member-delimiter-style`](./docs/rules/member-delimiter-style.md) — Require a specific member delimiter style for interfaces and type literals
+* [`typescript/member-ordering`](./docs/rules/member-ordering.md) — Require a consistent member declaration order (`member-ordering` from TSLint)
+* [`typescript/no-angle-bracket-type-assertion`](./docs/rules/no-angle-bracket-type-assertion.md) — Enforces the use of `as Type` assertions instead of `<Type>` assertions (`no-angle-bracket-type-assertion` from TSLint)
+* [`typescript/no-empty-interface`](./docs/rules/no-empty-interface.md) — Disallow the declaration of empty interfaces (`no-empty-interface` from TSLint)
+* [`typescript/no-explicit-any`](./docs/rules/no-explicit-any.md) — Disallow usage of the `any` type (`no-any` from TSLint)
+* [`typescript/no-namespace`](./docs/rules/no-namespace.md) — Disallow the use of custom TypeScript modules and namespaces
+* [`typescript/no-parameter-properties`](./docs/rules/no-parameter-properties.md) — Disallow the use of parameter properties in class constructors. (`no-parameter-properties` from TSLint)
+* [`typescript/no-triple-slash-reference`](./docs/rules/no-triple-slash-reference.md) — Disallow `/// <reference path="" />` comments (`no-reference` from TSLint)
+* [`typescript/no-type-alias`](./docs/rules/no-type-alias.md) — Disallow the use of type aliases (`interface-over-type-literal` from TSLint)
+* [`typescript/no-unused-vars`](./docs/rules/no-unused-vars.md) — Prevent TypeScript-specific constructs from being erroneously flagged as unused
+* [`typescript/no-use-before-define`](./docs/rules/no-use-before-define.md) — Disallow the use of variables before they are defined
+* [`typescript/prefer-namespace-keyword`](./docs/rules/prefer-namespace-keyword.md) — Require the use of the `namespace` keyword instead of the `module` keyword to declare custom TypeScript modules. (`no-internal-module` from TSLint)
+* [`typescript/type-annotation-spacing`](./docs/rules/type-annotation-spacing.md) — Require consistent spacing around type annotations
+<!-- end rule list -->

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ Then configure the rules you want to use under the rules section.
 
 ## Supported Rules
 
-* [`typescript/type-annotation-spacing`](./docs/rules/type-annotation-spacing.md) — enforces one space after the colon and zero spaces before the colon of a type annotation.
+* [`typescript/adjacent-overload-signatures`](./docs/rules/adjacent-overload-signatures.md) — enforces member overloads to be consecutive.
+* [`typescript/class-name-casing`](./docs/rules/adjacent-overload-signatures.md) - enforces PascalCased class and interface names. (`class-name` from TSLint)
 * [`typescript/explicit-member-accessibility`](./docs/rules/explicit-member-accessibility.md) — enforces accessibility modifiers on class properties and methods. (`member-access` from TSLint)
 * [`typescript/interface-name-prefix`](./docs/rules/interface-name-prefix.md) — enforces interface names are prefixed. (`interface-name` from TSLint)
-* [`typescript/no-triple-slash-reference`](./docs/rules/no-triple-slash-reference.md) — enforces `/// <reference />` is not used. (`no-reference` from TSLint)
-* [`typescript/no-explicit-any`](./docs/rules/no-explicit-any.md) — enforces the `any` type is not used. (`no-any` from TSLint)
+* [`typescript/member-delimiter-style`](./docs/rules/member-delimiter-style.md) - enforces a member delimiter style in interfaces and type literals.
+* [`typescript/member-ordering`](./docs/rules/member-ordering.md) — enforces a standard member declaration order. (`member-ordering` from TSLint)
 * [`typescript/no-angle-bracket-type-assertion`](./docs/rules/no-angle-bracket-type-assertion.md) — enforces the use of `as Type` assertions instead of `<Type>` assertions. (`no-angle-bracket-type-assertion` from TSLint)
+* [`typescript/no-empty-interface`](./docs/rules/no-empty-interface.md) - disallows the declaration of empty interfaces. (`no-empty-interface` from TSLint)
+* [`typescript/no-explicit-any`](./docs/rules/no-explicit-any.md) — enforces the `any` type is not used. (`no-any` from TSLint)
 * [`typescript/no-namespace`](./docs/rules/no-namespace.md) — disallows the use of custom TypeScript modules and namespaces.
+* [`typescript/no-parameter-properties`](./docs/rules/no-parameter-properties.md) - disallows parameter properties in class constructors. (`no-parameter-properties` from TSLint)
+* [`typescript/no-triple-slash-reference`](./docs/rules/no-triple-slash-reference.md) — enforces `/// <reference />` is not used. (`no-reference` from TSLint)
+* [`typescript/no-type-alias`](./docs/rules/no-type-alias.md) — disallows the use of type aliases. (`interface-over-type-literal` from TSLint)
+* [`typescript/no-unused-vars`](./docs/rules/no-unused-vars.md) — prevents TypeScript-specific constructs from being erroneously flagged as unused
 * [`typescript/no-use-before-define`](./docs/rules/no-use-before-define.md) — disallows the use of variables before they are defined.
 * [`typescript/prefer-namespace-keyword`](./docs/rules/prefer-namespace-keyword.md) — enforces the use of the keyword `namespace` over `module` to declare custom TypeScript modules. (`no-internal-module` from TSLint)
-* [`typescript/no-type-alias`](./docs/rules/no-type-alias.md) — disallows the use of type aliases. (`interface-over-type-literal` from TSLint)
-* [`typescript/member-ordering`](./docs/rules/member-ordering.md) — enforces a standard member declaration order. (`member-ordering` from TSLint)
-* [`typescript/no-unused-vars`](./docs/rules/no-unused-vars.md) — prevents TypeScript-specific constructs from being erroneously flagged as unused
-* [`typescript/adjacent-overload-signatures`](./docs/rules/adjacent-overload-signatures.md) — enforces member overloads to be consecutive.
-* [`typescript/no-parameter-properties`](./docs/rules/no-parameter-properties.md) - disallows parameter properties in class constructors. (`no-parameter-properties` from TSLint)
-* [`typescript/class-name-casing`](./docs/rules/adjacent-overload-signatures.md) - enforces PascalCased class and interface names. (`class-name` from TSLint)
-* [`typescript/member-delimiter-style`](./docs/rules/member-delimiter-style.md) - enforces a member delimiter style in interfaces and type literals.
-* [`typescript/no-empty-interface`](./docs/rules/no-empty-interface.md) - disallows the declaration of empty interfaces. (`no-empty-interface` from TSLint)
+* [`typescript/type-annotation-spacing`](./docs/rules/type-annotation-spacing.md) — enforces one space after the colon and zero spaces before the colon of a type annotation.

--- a/docs/rules/adjacent-overload-signatures.md
+++ b/docs/rules/adjacent-overload-signatures.md
@@ -1,4 +1,4 @@
-# Enforces member overloads to be consecutive.
+# Require that member overloads be consecutive (adjacent-overload-signatures)
 
 Grouping overloaded members together can improve readability of the code.
 

--- a/docs/rules/class-name-casing.md
+++ b/docs/rules/class-name-casing.md
@@ -1,4 +1,4 @@
-# Enforces PascalCased class and interface names. (class-name-casing)
+# Require PascalCased class and interface names (class-name-casing)
 
 This rule enforces PascalCased names for classes and interfaces.
 

--- a/docs/rules/explicit-member-accessibility.md
+++ b/docs/rules/explicit-member-accessibility.md
@@ -1,4 +1,4 @@
-# Enforces accessibility modifiers on class properties and methods (explicit-member-accessibility)
+# Require explicit accessibility modifiers on class properties and methods (explicit-member-accessibility)
 
 Leaving off accessibility modifier and making everything public can make
 your interface hard to use by others.

--- a/docs/rules/interface-name-prefix.md
+++ b/docs/rules/interface-name-prefix.md
@@ -1,4 +1,4 @@
-# Enforces interface names are prefixed
+# Require that interface names be prefixed with `I` (interface-name-prefix)
 
 It can be hard to differentiate between classes and interfaces.
 Prefixing interfaces with "I" can help telling them apart at a glance.

--- a/docs/rules/member-delimiter-style.md
+++ b/docs/rules/member-delimiter-style.md
@@ -1,4 +1,4 @@
-# Enforces a member delimiter style in interfaces and type literals.
+# Require a specific member delimiter style for interfaces and type literals (member-delimiter-style)
 
 Enforces a consistent member delimiter style in interfaces and type literals. There are three member delimiter styles primarily used in TypeScript:
 - Semicolon style (default, preferred in TypeScript).

--- a/docs/rules/member-naming.md
+++ b/docs/rules/member-naming.md
@@ -1,4 +1,4 @@
-# Enforces naming conventions for class members by visibility.
+# Enforces naming conventions for class members by visibility. (member-naming)
 
 It can be helpful to enforce naming conventions for `private` (and sometimes `protected`) members of an object. For example, prefixing private properties with a `_` allows them to be easily discerned when being inspected by tools that do not have knowledge of TypeScript (such as most debuggers).
 

--- a/docs/rules/member-ordering.md
+++ b/docs/rules/member-ordering.md
@@ -1,4 +1,4 @@
-# Enforces a standard member declaration order.
+# Require a consistent member declaration order (member-ordering)
 
 A consistent ordering of fields, methods and constructors can make interfaces, type literals, classes and class 
 expressions easier to read, navigate and edit.

--- a/docs/rules/no-angle-bracket-type-assertion.md
+++ b/docs/rules/no-angle-bracket-type-assertion.md
@@ -1,4 +1,4 @@
-# Enforces the use of `as Type` assertions instead of `<Type>` assertions.
+# Enforces the use of `as Type` assertions instead of `<Type>` assertions (no-angle-bracket-type-assertion)
 
 TypeScript disallows the use of `<Type>` assertions in `.tsx` because of the similarity with  
 JSX's syntax, which makes it impossible to parse. 

--- a/docs/rules/no-empty-interface.md
+++ b/docs/rules/no-empty-interface.md
@@ -1,4 +1,4 @@
-# Disallows the declaration of empty interfaces.
+# Disallow the declaration of empty interfaces (no-empty-interface)
 
 An empty interface is equivalent to its supertype. If the interface does not implement a supertype, then 
 the interface is equivalent to an empty object (`{}`). In both cases it can be omitted.

--- a/docs/rules/no-explicit-any.md
+++ b/docs/rules/no-explicit-any.md
@@ -1,4 +1,4 @@
-# Enforces the any type is not used (no-explicit-any)
+# Disallow usage of the `any` type (no-explicit-any)
 
 Using the `any` type defeats the purpose of using TypeScript.
 When `any` is used, all compiler type checks around that value are ignored.

--- a/docs/rules/no-namespace.md
+++ b/docs/rules/no-namespace.md
@@ -1,4 +1,4 @@
-# Disallows the use of `custom TypeScript modules` and `namespaces`.
+# Disallow the use of custom TypeScript modules and namespaces (no-namespace)
 
 Custom TypeScript modules (`module foo {}`) and namespaces (`namespace foo {}`) are considered outdated 
 ways to organize TypeScript code. ES2015 module syntax is now preferred (`import`/`export`).   

--- a/docs/rules/no-parameter-properties.md
+++ b/docs/rules/no-parameter-properties.md
@@ -1,4 +1,4 @@
-# Disallows parameter properties in class constructors.
+# Disallow the use of parameter properties in class constructors. (no-parameter-properties)
 
 Parameter properties can be confusing to those new to TypeScript as they are less explicit than other ways
 of declaring and initializing class members.

--- a/docs/rules/no-triple-slash-reference.md
+++ b/docs/rules/no-triple-slash-reference.md
@@ -1,4 +1,4 @@
-# Enforces reference comments are not used (no-triple-slash-reference)
+# Disallow `/// <reference path="" />` comments (no-triple-slash-reference)
 
 Triple-slash reference directive comments should not be used anymore. Use `import` instead.
 

--- a/docs/rules/no-type-alias.md
+++ b/docs/rules/no-type-alias.md
@@ -1,4 +1,4 @@
-# Disallows the use of type aliases. 
+# Disallow the use of type aliases (no-type-alias)
 
 In TypeScript, type aliases serve three purposes:
 - Aliasing other types so that we can refer to them using a simpler name.

--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -1,4 +1,4 @@
-# Disallow Early Use (no-use-before-define)
+# Disallow the use of variables before they are defined (no-use-before-define)
 
 In JavaScript, prior to ES6, variable and function declarations are hoisted to the top of a scope, so it's possible to use identifiers before their formal declarations in code. This can be confusing and some believe it is best to always declare variables and functions before using them.
 

--- a/docs/rules/prefer-namespace-keyword.md
+++ b/docs/rules/prefer-namespace-keyword.md
@@ -1,4 +1,4 @@
-# Enforces the use of the keyword `namespace` over `module` to declare custom TypeScript modules.
+# Require the use of the `namespace` keyword instead of the `module` keyword to declare custom TypeScript modules. (prefer-namespace-keyword)
 
 In an effort to prevent further confusion between custom TypeScript modules and the new ES2015 modules, starting
 with TypeScript v1.5 the keyword `namespace` is now the preferred way to declare custom TypeScript modules. 

--- a/docs/rules/type-annotation-spacing.md
+++ b/docs/rules/type-annotation-spacing.md
@@ -1,4 +1,4 @@
-# Enforces spacing around type annotations (type-annotation-spacing)
+# Require consistent spacing around type annotations (type-annotation-spacing)
 
 Spacing around type annotations improves readability of the code. Although the most commonly used style guideline for type annotations in TypeScript prescribes adding a space after the colon, but not before it, it is subjective to the preferences of a project. For example:
 

--- a/lib/rules/adjacent-overload-signatures.js
+++ b/lib/rules/adjacent-overload-signatures.js
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "Enforces member overloads to be consecutive",
+            description: "Require that member overloads be consecutive",
             category: "TypeScript"
         },
         schema: []

--- a/lib/rules/class-name-casing.js
+++ b/lib/rules/class-name-casing.js
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "Enforces PascalCased class and interface names.",
+            description: "Require PascalCased class and interface names",
             category: "Best Practices",
             recommended: true
         }

--- a/lib/rules/class-name-casing.js
+++ b/lib/rules/class-name-casing.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -12,6 +14,7 @@ module.exports = {
     meta: {
         docs: {
             description: "Require PascalCased class and interface names",
+            extraDescription: [util.tslintRule("class-name")],
             category: "Best Practices",
             recommended: true
         }

--- a/lib/rules/explicit-member-accessibility.js
+++ b/lib/rules/explicit-member-accessibility.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -13,6 +15,7 @@ module.exports = {
         docs: {
             description:
                 "Require explicit accessibility modifiers on class properties and methods",
+            extraDescription: [util.tslintRule("member-access")],
             category: "TypeScript"
         },
         schema: []

--- a/lib/rules/explicit-member-accessibility.js
+++ b/lib/rules/explicit-member-accessibility.js
@@ -12,7 +12,7 @@ module.exports = {
     meta: {
         docs: {
             description:
-                "Enforces explicity accessibility modifiers for class members",
+                "Require explicit accessibility modifiers on class properties and methods",
             category: "TypeScript"
         },
         schema: []

--- a/lib/rules/interface-name-prefix.js
+++ b/lib/rules/interface-name-prefix.js
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: 'Enforces interface names are prefixed with "I".',
+            description: "Require that interface names be prefixed with `I`",
             category: "TypeScript"
         },
         schema: [

--- a/lib/rules/interface-name-prefix.js
+++ b/lib/rules/interface-name-prefix.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -12,6 +14,7 @@ module.exports = {
     meta: {
         docs: {
             description: "Require that interface names be prefixed with `I`",
+            extraDescription: [util.tslintRule("interface-name")],
             category: "TypeScript"
         },
         schema: [

--- a/lib/rules/member-delimiter-style.js
+++ b/lib/rules/member-delimiter-style.js
@@ -22,7 +22,7 @@ module.exports = {
     meta: {
         docs: {
             description:
-                "Enforces a member delimiter style for interfaces and type literals.",
+                "Require a specific member delimiter style for interfaces and type literals",
             category: "TypeScript"
         },
         fixable: "code",

--- a/lib/rules/member-ordering.js
+++ b/lib/rules/member-ordering.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -34,6 +36,7 @@ module.exports = {
     meta: {
         docs: {
             description: "Require a consistent member declaration order",
+            extraDescription: [util.tslintRule("member-ordering")],
             category: "TypeScript"
         },
         schema: [

--- a/lib/rules/member-ordering.js
+++ b/lib/rules/member-ordering.js
@@ -33,7 +33,7 @@ const schemaOptions = [
 module.exports = {
     meta: {
         docs: {
-            description: "Enforces a standard member declaration order.",
+            description: "Require a consistent member declaration order",
             category: "TypeScript"
         },
         schema: [

--- a/lib/rules/no-angle-bracket-type-assertion.js
+++ b/lib/rules/no-angle-bracket-type-assertion.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -13,6 +15,9 @@ module.exports = {
         docs: {
             description:
                 "Enforces the use of `as Type` assertions instead of `<Type>` assertions",
+            extraDescription: [
+                util.tslintRule("no-angle-bracket-type-assertion")
+            ],
             category: "Style"
         },
         schema: []

--- a/lib/rules/no-angle-bracket-type-assertion.js
+++ b/lib/rules/no-angle-bracket-type-assertion.js
@@ -12,7 +12,7 @@ module.exports = {
     meta: {
         docs: {
             description:
-                "Enforces the use of as Type assertions instead of <Type> assertions.",
+                "Enforces the use of `as Type` assertions instead of `<Type>` assertions",
             category: "Style"
         },
         schema: []

--- a/lib/rules/no-empty-interface.js
+++ b/lib/rules/no-empty-interface.js
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "Disallows the declaration of empty interfaces.",
+            description: "Disallow the declaration of empty interfaces",
             category: "TypeScript"
         },
         schema: []

--- a/lib/rules/no-empty-interface.js
+++ b/lib/rules/no-empty-interface.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -12,6 +14,7 @@ module.exports = {
     meta: {
         docs: {
             description: "Disallow the declaration of empty interfaces",
+            extraDescription: [util.tslintRule("no-empty-interface")],
             category: "TypeScript"
         },
         schema: []

--- a/lib/rules/no-explicit-any.js
+++ b/lib/rules/no-explicit-any.js
@@ -5,6 +5,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -13,6 +15,7 @@ module.exports = {
     meta: {
         docs: {
             description: "Disallow usage of the `any` type",
+            extraDescription: [util.tslintRule("no-any")],
             category: "TypeScript"
         },
         schema: []

--- a/lib/rules/no-explicit-any.js
+++ b/lib/rules/no-explicit-any.js
@@ -12,7 +12,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "Enforces the any type is not used.",
+            description: "Disallow usage of the `any` type",
             category: "TypeScript"
         },
         schema: []

--- a/lib/rules/no-namespace.js
+++ b/lib/rules/no-namespace.js
@@ -12,7 +12,7 @@ module.exports = {
     meta: {
         docs: {
             description:
-                "Disallows the use of custom TypeScript modules and namespaces.",
+                "Disallow the use of custom TypeScript modules and namespaces",
             category: "TypeScript"
         },
         schema: [

--- a/lib/rules/no-parameter-properties.js
+++ b/lib/rules/no-parameter-properties.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -13,6 +15,7 @@ module.exports = {
         docs: {
             description:
                 "Disallow the use of parameter properties in class constructors.",
+            extraDescription: [util.tslintRule("no-parameter-properties")],
             category: "TypeScript"
         },
         schema: [

--- a/lib/rules/no-parameter-properties.js
+++ b/lib/rules/no-parameter-properties.js
@@ -12,7 +12,7 @@ module.exports = {
     meta: {
         docs: {
             description:
-                "Disallows parameter properties in class constructors.",
+                "Disallow the use of parameter properties in class constructors.",
             category: "TypeScript"
         },
         schema: [

--- a/lib/rules/no-triple-slash-reference.js
+++ b/lib/rules/no-triple-slash-reference.js
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "Enforces triple slash references are not used.",
+            description: 'Disallow `/// <reference path="" />` comments',
             category: "TypeScript"
         },
         schema: []

--- a/lib/rules/no-triple-slash-reference.js
+++ b/lib/rules/no-triple-slash-reference.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -12,6 +14,7 @@ module.exports = {
     meta: {
         docs: {
             description: 'Disallow `/// <reference path="" />` comments',
+            extraDescription: [util.tslintRule("no-reference")],
             category: "TypeScript"
         },
         schema: []

--- a/lib/rules/no-type-alias.js
+++ b/lib/rules/no-type-alias.js
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "Disallows the use of type aliases.",
+            description: "Disallow the use of type aliases",
             category: "TypeScript"
         },
         schema: [

--- a/lib/rules/no-type-alias.js
+++ b/lib/rules/no-type-alias.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -12,6 +14,7 @@ module.exports = {
     meta: {
         docs: {
             description: "Disallow the use of type aliases",
+            extraDescription: [util.tslintRule("interface-over-type-literal")],
             category: "TypeScript"
         },
         schema: [

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -47,7 +47,7 @@ module.exports = {
     meta: {
         docs: {
             description:
-                "Prevent TypeScript-specific variables being falsely marked as unused.",
+                "Prevent TypeScript-specific constructs from being erroneously flagged as unused",
             category: "TypeScript",
             recommended: true
         },

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -156,7 +156,7 @@ module.exports = {
     meta: {
         docs: {
             description:
-                "disallow the use of variables before they are defined",
+                "Disallow the use of variables before they are defined",
             category: "Variables",
             recommended: false
         },

--- a/lib/rules/prefer-namespace-keyword.js
+++ b/lib/rules/prefer-namespace-keyword.js
@@ -12,7 +12,7 @@ module.exports = {
     meta: {
         docs: {
             description:
-                "Enforces the use of the keyword namespace over module to declare custom TypeScript modules.",
+                "Require the use of the `namespace` keyword instead of the `module` keyword to declare custom TypeScript modules.",
             category: "TypeScript"
         },
         fixable: "code",

--- a/lib/rules/prefer-namespace-keyword.js
+++ b/lib/rules/prefer-namespace-keyword.js
@@ -70,7 +70,7 @@ module.exports = {
                 context.report({
                     node,
                     message:
-                        "Use namespace instead of module to declare custom TypeScript modules",
+                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
                     fix(fixer) {
                         const start = getStartIndex(node);
 

--- a/lib/rules/prefer-namespace-keyword.js
+++ b/lib/rules/prefer-namespace-keyword.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -13,6 +15,7 @@ module.exports = {
         docs: {
             description:
                 "Require the use of the `namespace` keyword instead of the `module` keyword to declare custom TypeScript modules.",
+            extraDescription: [util.tslintRule("no-internal-module")],
             category: "TypeScript"
         },
         fixable: "code",

--- a/lib/rules/type-annotation-spacing.js
+++ b/lib/rules/type-annotation-spacing.js
@@ -21,7 +21,7 @@ const definition = {
 module.exports = {
     meta: {
         docs: {
-            description: "Enforces spacing around type annotations.",
+            description: "Require consistent spacing around type annotations",
             category: "TypeScript"
         },
         fixable: "code",

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports.tslintRule = name => `\`${name}\` from TSLint`;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^4.5.0",
     "eslint-config-eslint": "^4.0.0",
     "eslint-config-prettier": "^2.3.0",
-    "eslint-docs": "^0.0.5",
+    "eslint-docs": "^0.1.0",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-prettier": "^2.2.0",
     "husky": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "eslint lib/ tests/ --fix",
     "docs": "eslint-docs",
     "docs:check": "eslint-docs check",
-    "test": "npm run lint && npm run mocha",
+    "mocha": "mocha tests --recursive --reporter=dot",
     "test": "npm run lint && npm run mocha && npm run docs:check",
     "precommit": "npm test && lint-staged"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^4.5.0",
     "eslint-config-eslint": "^4.0.0",
     "eslint-config-prettier": "^2.3.0",
-    "eslint-docs": "^0.1.0",
+    "eslint-docs": "^0.1.1",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-prettier": "^2.2.0",
     "husky": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   "scripts": {
     "lint": "eslint lib/ tests/",
     "lint:fix": "eslint lib/ tests/ --fix",
+    "docs": "eslint-docs",
+    "docs:check": "eslint-docs check",
     "mocha": "mocha tests --recursive",
-    "test": "npm run lint && npm run mocha",
+    "test": "npm run lint && npm run mocha && npm run docs:check",
     "precommit": "npm test && lint-staged"
   },
   "dependencies": {
@@ -24,6 +26,7 @@
     "eslint": "^4.5.0",
     "eslint-config-eslint": "^4.0.0",
     "eslint-config-prettier": "^2.3.0",
+    "eslint-docs": "^0.0.5",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-prettier": "^2.2.0",
     "husky": "^0.14.3",

--- a/tests/lib/rules/prefer-namespace-keyword.js
+++ b/tests/lib/rules/prefer-namespace-keyword.js
@@ -39,7 +39,7 @@ ruleTester.run("prefer-namespace-keyword", rule, {
             errors: [
                 {
                     message:
-                        "Use namespace instead of module to declare custom TypeScript modules",
+                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
                     output: "namespace foo { }",
                     row: 1,
                     column: 1
@@ -52,7 +52,7 @@ ruleTester.run("prefer-namespace-keyword", rule, {
             errors: [
                 {
                     message:
-                        "Use namespace instead of module to declare custom TypeScript modules",
+                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
                     output: "declare namespace foo { }",
                     row: 1,
                     column: 1
@@ -69,14 +69,14 @@ declare module foo {
             errors: [
                 {
                     message:
-                        "Use namespace instead of module to declare custom TypeScript modules",
+                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
                     output: "declare namespace foo { }",
                     row: 2,
                     column: 1
                 },
                 {
                     message:
-                        "Use namespace instead of module to declare custom TypeScript modules",
+                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
                     output: `
 declare namespace foo {
     declare namespace bar { }


### PR DESCRIPTION
`eslint-docs` copies the rule description from the rule’s source file to a list of rules in the README and to the top of the rule documentation file. This prevents descriptions from getting out of sync, and it could check for other patterns in the future. 

**Note**: I am the creator of the `eslint-docs` project.