### PR TITLE
Fix no-triple-slash-reference

### DIFF
--- a/lib/rules/no-triple-slash-reference.js
+++ b/lib/rules/no-triple-slash-reference.js
@@ -32,9 +32,9 @@ module.exports = {
          * @private
          */
         function checkTripleSlashReference(program) {
-            const leading = sourceCode.getComments(program).leading;
+            const commentsBefore = sourceCode.getCommentsBefore(program);
 
-            leading.forEach(comment => {
+            commentsBefore.forEach(comment => {
                 if (comment.type !== "Line") {
                     return;
                 }

--- a/tests/lib/rules/no-triple-slash-reference.js
+++ b/tests/lib/rules/no-triple-slash-reference.js
@@ -30,6 +30,17 @@ ruleTester.run("no-triple-slash-reference", rule, {
     ],
     invalid: [
         {
+            code: '/// <reference path="Animal" />',
+            parser: "typescript-eslint-parser",
+            errors: [
+                {
+                    message: "Do not use a triple slash reference",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        },
+        {
             code: '/// <reference path="Animal" />\nlet a',
             parser: "typescript-eslint-parser",
             errors: [

--- a/tests/lib/rules/no-triple-slash-reference.js
+++ b/tests/lib/rules/no-triple-slash-reference.js
@@ -30,7 +30,7 @@ ruleTester.run("no-triple-slash-reference", rule, {
     ],
     invalid: [
         {
-            code: '/// <reference path="Animal" />',
+            code: '/// <reference path="Animal" />\nlet a',
             parser: "typescript-eslint-parser",
             errors: [
                 {

--- a/tests/lib/rules/no-triple-slash-reference.js
+++ b/tests/lib/rules/no-triple-slash-reference.js
@@ -41,12 +41,15 @@ ruleTester.run("no-triple-slash-reference", rule, {
             ]
         },
         {
-            code: '/// <reference path="Animal" />\nlet a',
+            code: `
+/// <reference path="Animal" />
+let a
+            `,
             parser: "typescript-eslint-parser",
             errors: [
                 {
                     message: "Do not use a triple slash reference",
-                    line: 1,
+                    line: 2,
                     column: 1
                 }
             ]


### PR DESCRIPTION
Trying this rule, I had to fix it by replacing `getComments` with `getCommentsBefore`.

Anyway, [`getComments` seems deprecated](https://eslint.org/docs/developer-guide/working-with-rules#deprecated).