### PR TITLE
no-unused-vars: `Type[]` doesn't mark `Type` as used

### DIFF
--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -246,6 +246,14 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
         {
             code: [
                 "import { Nullable } from 'nullable'",
+                "const a: Nullable[] = 'hello'",
+                "console.log(a)"
+            ].join("\n"),
+            parser
+        },
+        {
+            code: [
+                "import { Nullable } from 'nullable'",
                 "const a: Array<Nullable[]> = 'hello'",
                 "console.log(a)"
             ].join("\n"),


### PR DESCRIPTION
Well, I spent some time on this. Here is a PR with a failing test case.

I would *really* like to see the solution to this, because from my debugging, the identifier `Type` does get marked as used. So why the fail?