### PR TITLE
Fix: array references marked as used (fixes #77)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -69,6 +69,10 @@ module.exports = {
             const annotation = node.typeAnnotation || node;
 
             switch (annotation.type) {
+                case "TSArrayType": {
+                    markTypeAnnotationAsUsed(annotation.elementType);
+                    break;
+                }
                 case "TSTypeReference": {
                     if (annotation.typeName.type === "TSArrayType") {
                         markTypeAnnotationAsUsed(

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -246,6 +246,14 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
         {
             code: [
                 "import { Nullable } from 'nullable'",
+                "const a: Nullable[] = 'hello'",
+                "console.log(a)"
+            ].join("\n"),
+            parser
+        },
+        {
+            code: [
+                "import { Nullable } from 'nullable'",
                 "const a: Array<Nullable[]> = 'hello'",
                 "console.log(a)"
             ].join("\n"),

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -410,6 +410,14 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "}"
             ].join("\n"),
             parser
+        },
+        {
+            code: [
+                "import { Nullable } from 'nullable'",
+                "const a: Nullable[] = 'hello'",
+                "console.log(a)"
+            ].join("\n"),
+            parser
         }
     ],
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -410,14 +410,6 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 "}"
             ].join("\n"),
             parser
-        },
-        {
-            code: [
-                "import { Nullable } from 'nullable'",
-                "const a: Nullable[] = 'hello'",
-                "console.log(a)"
-            ].join("\n"),
-            parser
         }
     ],
 


### PR DESCRIPTION
Includes another case for no-unused-vars. Now Array types are marked as used.