### PR TITLE
Fix: Handles type spacing on TSParenthesizedType expressions (fixes #79)

### DIFF
--- a/lib/rules/type-annotation-spacing.js
+++ b/lib/rules/type-annotation-spacing.js
@@ -45,6 +45,7 @@ module.exports = {
     },
 
     create(context) {
+        const punctuators = [":", "=>"];
         const sourceCode = context.getSourceCode();
         const options = context.options[0] || {};
 
@@ -78,12 +79,16 @@ module.exports = {
             const nextToken = typeAnnotation;
             const punctuatorToken = sourceCode.getTokenBefore(nextToken);
             const previousToken = sourceCode.getTokenBefore(punctuatorToken);
+            const type = punctuatorToken.value;
+
+            if (punctuators.indexOf(type) === -1) {
+                return;
+            }
 
             const previousDelta =
                 punctuatorToken.range[0] - previousToken.range[1];
             const nextDelta = nextToken.range[0] - punctuatorToken.range[1];
 
-            const type = punctuatorToken.value;
             const before =
                 type === ":" ? colonOptions.before : arrowOptions.before;
             const after =
@@ -159,9 +164,7 @@ module.exports = {
                 }
             },
             TypeAnnotation(node) {
-                if (node.parent.type !== "TSAsExpression") {
-                    checkTypeAnnotationSpacing(node.typeAnnotation);
-                }
+                checkTypeAnnotationSpacing(node.typeAnnotation);
             },
             FunctionDeclaration: checkFunctionReturnTypeSpacing,
             FunctionExpression: checkFunctionReturnTypeSpacing,

--- a/tests/lib/rules/type-annotation-spacing.js
+++ b/tests/lib/rules/type-annotation-spacing.js
@@ -20,6 +20,14 @@ const ruleTester = new RuleTester();
 ruleTester.run("type-annotation-spacing", rule, {
     valid: [
         {
+            code: `
+interface resolve {
+    resolver: (() => PromiseLike<T>) | PromiseLike<T>;
+}
+            `,
+            parser: "typescript-eslint-parser"
+        },
+        {
             code: "const foo = {} as Foo;",
             parser: "typescript-eslint-parser"
         },
@@ -1174,6 +1182,18 @@ class Foo {
 }
             `,
             options: [{ before: true }],
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: "let resolver: (() => PromiseLike<T>) | PromiseLike<T>;",
+            parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface resolve {
+    resolver: (() => PromiseLike<T>) | PromiseLike<T>;
+}
+            `,
             parser: "typescript-eslint-parser"
         }
     ],


### PR DESCRIPTION
Handles constructors like.

```ts
interface A {
    resolver: (() => PromiseLike<T>) | PromiseLike<T>;
}
```

By excluding punctuators other than `:` and `=>` from the validation