### PR TITLE
Destructured param type annotation not marked used

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -92,6 +92,15 @@ module.exports = {
 
                     break;
                 }
+                case "TSTypeLiteral": {
+                    annotation.members.forEach(member => {
+                        if (member.typeAnnotation) {
+                            markTypeAnnotationAsUsed(member.typeAnnotation);
+                        }
+                    });
+
+                    break;
+                }
                 case "TSUnionType":
                 case "TSIntersectionType":
                     annotation.types.forEach(type => {
@@ -256,6 +265,12 @@ module.exports = {
 
             ClassDeclaration: markClassOptionsAsUsed,
             ClassExpression: markClassOptionsAsUsed,
+
+            ObjectPattern(node) {
+                if (node.typeAnnotation) {
+                    markTypeAnnotationAsUsed(node.typeAnnotation);
+                }
+            },
 
             MethodDefinition(node) {
                 if (node.decorators) {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -383,6 +383,14 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
         },
         {
             code: [
+                "import { ReproInterface } from 'ReproInterface'",
+                "const x = ({ a = null } : { a: ReproInterface }) => a",
+                "console.log(x)"
+            ].join("\n"),
+            parser
+        },
+        {
+            code: [
                 "import { Nullable } from 'nullable'",
                 "import { SomeOther } from 'some'",
                 "import { Another } from 'some'",

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -376,8 +376,8 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
         {
             code: [
                 "import { Nullable } from 'nullable'",
-                "const foo = ({ nullable }: Nullable)  => nullable",
-                "foo()"
+                "const foo = ({ nullable }: Nullable) => nullable",
+                "foo({ nullable: null })"
             ].join("\n"),
             parser
         },

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -376,6 +376,14 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
         {
             code: [
                 "import { Nullable } from 'nullable'",
+                "const foo = ({ nullable }: Nullable)  => nullable",
+                "foo()"
+            ].join("\n"),
+            parser
+        },
+        {
+            code: [
+                "import { Nullable } from 'nullable'",
                 "import { SomeOther } from 'some'",
                 "import { Another } from 'some'",
                 "class A extends Nullable<SomeOther> {",


### PR DESCRIPTION
Here is a failing seemingly valid test code.