### PR TITLE
Fix: Mark call expression type parameters as used

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -251,6 +251,14 @@ module.exports = {
             FunctionExpression: markFunctionReturnTypeAsUsed,
             ArrowFunctionExpression: markFunctionReturnTypeAsUsed,
 
+            CallExpression(node) {
+                if (node.typeParameters && node.typeParameters.params) {
+                    node.typeParameters.params.forEach(
+                        markTypeAnnotationAsUsed
+                    );
+                }
+            },
+
             Decorator: markDecoratorAsUsed,
             TSInterfaceHeritage: markExtendedInterfaceAsUsed,
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -186,6 +186,36 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
         },
         {
             code: [
+                "import { Foo } from 'foo'",
+                "function bar<T>() {}",
+                "bar<Foo>()"
+            ].join("\n"),
+            parser
+        },
+        {
+            code: [
+                "import { Foo } from 'foo'",
+                "const bar = function <T>() {}",
+                "bar<Foo>()"
+            ].join("\n"),
+            parser
+        },
+        {
+            code: [
+                "import { Foo } from 'foo'",
+                "const bar = <T>() => {}",
+                "bar<Foo>()"
+            ].join("\n"),
+            parser
+        },
+        {
+            code: ["import { Foo } from 'foo'", "<Foo>(<T>() => {})()"].join(
+                "\n"
+            ),
+            parser
+        },
+        {
+            code: [
                 "import { Nullable } from 'nullable'",
                 "const a: Nullable<string> = 'hello'",
                 "console.log(a)"
@@ -432,6 +462,21 @@ ruleTester.run("no-unused-vars", ruleNoUnusedVars, {
                 {
                     message:
                         "'ClassDecoratorFactory' is defined but never used.",
+                    line: 1,
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: [
+                "import { Foo, Bar } from 'foo';",
+                "function baz<Foo>() {}",
+                "baz<Bar>()"
+            ].join("\n"),
+            parser,
+            errors: [
+                {
+                    message: "'Foo' is defined but never used.",
                     line: 1,
                     column: 10
                 }


### PR DESCRIPTION
While type parameters on function declarations/expressions are marked as used, ones on call expressions are not, e.g.:

```ts
import { Foo } from 'foo'
function bar<T>() {}
bar<Foo>() // fails with no-unused-vars
```