### PR TITLE
failing test: type-annotation-spacing: keyof considered like arrow

### DIFF
--- a/tests/lib/rules/type-annotation-spacing.js
+++ b/tests/lib/rules/type-annotation-spacing.js
@@ -1175,6 +1175,25 @@ class Foo {
             `,
             options: [{ before: true }],
             parser: "typescript-eslint-parser"
+        },
+        {
+            code: `
+interface Foo { a: string }
+type Bar = Record<keyof Foo, string>
+            `,
+            options: [
+                {
+                    after: true,
+                    before: false,
+                    overrides: {
+                        arrow: {
+                            after: true,
+                            before: true
+                        }
+                    }
+                }
+            ],
+            parser: "typescript-eslint-parser"
         }
     ],
     invalid: [


### PR DESCRIPTION
Perhaps there should be more override types to go with `colon` and `arrow`?

This particular example is straight out of no-one's style guide, I assume.