### PR TITLE
Fix class-name-casing cannot recognize PascalCase containing digits

### DIFF
--- a/lib/rules/class-name-casing.js
+++ b/lib/rules/class-name-casing.js
@@ -33,9 +33,7 @@ module.exports = {
          * @returns {boolean}      Is the name PascalCased?
          */
         function isPascalCase(name) {
-            return (
-                name[0].toUpperCase() === name[0] && /^[A-Za-z]+$/.test(name)
-            );
+            return /^[A-Z][0-9A-Za-z]*$/.test(name);
         }
 
         /**

--- a/tests/lib/rules/class-name-casing.js
+++ b/tests/lib/rules/class-name-casing.js
@@ -29,7 +29,8 @@ ruleTester.run("class-name-casing", rule, {
             }
         },
         "var Foo = class {};",
-        "interface SomeInterface {}"
+        "interface SomeInterface {}",
+        "class ClassNameWithDigit2 {}"
     ],
 
     invalid: [


### PR DESCRIPTION
When `class-name-casing` is enabled, `class Foo2 {}` will be reported as invalid.