### PR TITLE
Update: explicit-member-accessibility only check *.ts and *.tsx files (Fixes #102)

### DIFF
--- a/lib/rules/explicit-function-return-type.js
+++ b/lib/rules/explicit-function-return-type.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const util = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -50,16 +52,6 @@ module.exports = {
         }
 
         /**
-         * Check if the context file name is *.ts or *.tsx
-         * @param {string} fileName The context file name
-         * @returns {boolean} `true` if the file name ends in *.ts or *.tsx
-         * @private
-         */
-        function isTypescript(fileName) {
-            return /\.(ts|tsx)$/.test(fileName);
-        }
-
-        /**
          * Checks if a function declaration/expression has a return type.
          * @param {ASTNode} node The node representing a function.
          * @returns {void}
@@ -70,7 +62,7 @@ module.exports = {
                 !node.returnType &&
                 !isConstructor(node.parent) &&
                 !isSetter(node.parent) &&
-                isTypescript(context.getFilename())
+                util.isTypescript(context.getFilename())
             ) {
                 context.report({
                     node,

--- a/lib/rules/explicit-member-accessibility.js
+++ b/lib/rules/explicit-member-accessibility.js
@@ -29,16 +29,6 @@ module.exports = {
         //----------------------------------------------------------------------
 
         /**
-         * Check if the context file name is *.ts or *.tsx
-         * @param {string} fileName The context file name
-         * @returns {boolean} `true` if the file name ends in *.ts or *.tsx
-         * @private
-         */
-        function isTypescript(fileName) {
-            return /\.(ts|tsx)$/.test(fileName);
-        }
-
-        /**
          * Checks if a method declaration has an accessibility modifier.
          * @param {ASTNode} methodDefinition The node representing a MethodDefinition.
          * @returns {void}
@@ -47,7 +37,7 @@ module.exports = {
         function checkMethodAccessibilityModifier(methodDefinition) {
             if (
                 !methodDefinition.accessibility &&
-                isTypescript(context.getFilename())
+                util.isTypescript(context.getFilename())
             ) {
                 context.report({
                     node: methodDefinition,
@@ -67,7 +57,7 @@ module.exports = {
         function checkPropertyAccessibilityModifier(classProperty) {
             if (
                 !classProperty.accessibility &&
-                isTypescript(context.getFilename())
+                util.isTypescript(context.getFilename())
             ) {
                 context.report({
                     node: classProperty,

--- a/lib/rules/explicit-member-accessibility.js
+++ b/lib/rules/explicit-member-accessibility.js
@@ -29,13 +29,26 @@ module.exports = {
         //----------------------------------------------------------------------
 
         /**
+         * Check if the context file name is *.ts or *.tsx
+         * @param {string} fileName The context file name
+         * @returns {boolean} `true` if the file name ends in *.ts or *.tsx
+         * @private
+         */
+        function isTypescript(fileName) {
+            return /\.(ts|tsx)$/.test(fileName);
+        }
+
+        /**
          * Checks if a method declaration has an accessibility modifier.
          * @param {ASTNode} methodDefinition The node representing a MethodDefinition.
          * @returns {void}
          * @private
          */
         function checkMethodAccessibilityModifier(methodDefinition) {
-            if (!methodDefinition.accessibility) {
+            if (
+                !methodDefinition.accessibility &&
+                isTypescript(context.getFilename())
+            ) {
                 context.report({
                     node: methodDefinition,
                     message: `Missing accessibility modifier on method definition ${
@@ -52,7 +65,10 @@ module.exports = {
          * @private
          */
         function checkPropertyAccessibilityModifier(classProperty) {
-            if (!classProperty.accessibility) {
+            if (
+                !classProperty.accessibility &&
+                isTypescript(context.getFilename())
+            ) {
                 context.report({
                     node: classProperty,
                     message: `Missing accessibility modifier on class property ${

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,11 @@
 "use strict";
 
 exports.tslintRule = name => `\`${name}\` from TSLint`;
+
+/**
+ * Check if the context file name is *.ts or *.tsx
+ * @param {string} fileName The context file name
+ * @returns {boolean} `true` if the file name ends in *.ts or *.tsx
+ * @private
+ */
+exports.isTypescript = fileName => /\.(ts|tsx)$/.test(fileName);

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,4 +8,4 @@ exports.tslintRule = name => `\`${name}\` from TSLint`;
  * @returns {boolean} `true` if the file name ends in *.ts or *.tsx
  * @private
  */
-exports.isTypescript = fileName => /\.(ts|tsx)$/.test(fileName);
+exports.isTypescript = fileName => /\.tsx?$/.test(fileName);

--- a/tests/lib/rules/explicit-member-accessibility.js
+++ b/tests/lib/rules/explicit-member-accessibility.js
@@ -21,7 +21,9 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("explicit-member-accessibility", rule, {
     valid: [
-        `
+        {
+            filename: "test.ts",
+            code: `
 class Test {
   protected name: string
   private x: number
@@ -29,10 +31,22 @@ class Test {
     return this.x
   }
 }
-        `
+            `
+        },
+        {
+            filename: "test.js",
+            code: `
+class Test {
+  getX () {
+    return 1;
+  }
+}
+            `
+        }
     ],
     invalid: [
         {
+            filename: "test.ts",
             code: `
 class Test {
   x: number
@@ -51,6 +65,7 @@ class Test {
             ]
         },
         {
+            filename: "test.ts",
             code: `
 class Test {
   private x: number


### PR DESCRIPTION
Modifies the `explicit-member-accessibility` rule by restricting it to only checking *.ts and *.tsx files (Fixes #102).

Note: the proposed new rule `explicit-function-return-type` (#103) has similar functionality (both rules duplicate the `isTypescript(filename)` function.  It may be desirable to move this duplicated function into `utils.js`, so it is available to any rule that needs to limit itself to only operating against Typescript files.