### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/lib/rules/adjacent-overload-signatures.js
+++ b/lib/rules/adjacent-overload-signatures.js
@@ -12,7 +12,9 @@ module.exports = {
     meta: {
         docs: {
             description: "Require that member overloads be consecutive",
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/adjacent-overload-signatures.md"
         },
         schema: []
     },

--- a/lib/rules/class-name-casing.js
+++ b/lib/rules/class-name-casing.js
@@ -16,7 +16,9 @@ module.exports = {
             description: "Require PascalCased class and interface names",
             extraDescription: [util.tslintRule("class-name")],
             category: "Best Practices",
-            recommended: true
+            recommended: true,
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/class-name-casing.md"
         }
     },
 

--- a/lib/rules/explicit-function-return-type.js
+++ b/lib/rules/explicit-function-return-type.js
@@ -13,7 +13,10 @@ module.exports = {
         docs: {
             description:
                 "Require explicit return types on functions and class methods",
-            category: "TypeScript"
+
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/explicit-function-return-type.md"
         },
         schema: []
     },

--- a/lib/rules/explicit-member-accessibility.js
+++ b/lib/rules/explicit-member-accessibility.js
@@ -16,7 +16,9 @@ module.exports = {
             description:
                 "Require explicit accessibility modifiers on class properties and methods",
             extraDescription: [util.tslintRule("member-access")],
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/explicit-member-accessibility.md"
         },
         schema: []
     },

--- a/lib/rules/interface-name-prefix.js
+++ b/lib/rules/interface-name-prefix.js
@@ -15,7 +15,9 @@ module.exports = {
         docs: {
             description: "Require that interface names be prefixed with `I`",
             extraDescription: [util.tslintRule("interface-name")],
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/interface-name-prefix.md"
         },
         schema: [
             {

--- a/lib/rules/member-delimiter-style.js
+++ b/lib/rules/member-delimiter-style.js
@@ -23,7 +23,9 @@ module.exports = {
         docs: {
             description:
                 "Require a specific member delimiter style for interfaces and type literals",
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/member-delimiter-style.md"
         },
         fixable: "code",
         schema: [

--- a/lib/rules/member-naming.js
+++ b/lib/rules/member-naming.js
@@ -13,7 +13,9 @@ module.exports = {
         docs: {
             description:
                 "Enforces naming conventions for class members by visibility.",
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/member-naming.md"
         },
         schema: [
             {

--- a/lib/rules/member-ordering.js
+++ b/lib/rules/member-ordering.js
@@ -36,7 +36,9 @@ module.exports = {
         docs: {
             description: "Require a consistent member declaration order",
             extraDescription: [util.tslintRule("member-ordering")],
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/member-ordering.md"
         },
         schema: [
             {

--- a/lib/rules/no-angle-bracket-type-assertion.js
+++ b/lib/rules/no-angle-bracket-type-assertion.js
@@ -18,7 +18,9 @@ module.exports = {
             extraDescription: [
                 util.tslintRule("no-angle-bracket-type-assertion")
             ],
-            category: "Style"
+            category: "Style",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-angle-bracket-type-assertion.md"
         },
         schema: []
     },

--- a/lib/rules/no-array-constructor.js
+++ b/lib/rules/no-array-constructor.js
@@ -14,7 +14,9 @@ module.exports = {
         docs: {
             description: "Disallow generic `Array` constructors",
             category: "Stylistic Issues",
-            recommended: false
+            recommended: false,
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-array-constructor.md"
         },
         fixable: "code",
         schema: []

--- a/lib/rules/no-empty-interface.js
+++ b/lib/rules/no-empty-interface.js
@@ -15,7 +15,9 @@ module.exports = {
         docs: {
             description: "Disallow the declaration of empty interfaces",
             extraDescription: [util.tslintRule("no-empty-interface")],
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-empty-interface.md"
         },
         schema: []
     },

--- a/lib/rules/no-explicit-any.js
+++ b/lib/rules/no-explicit-any.js
@@ -16,7 +16,9 @@ module.exports = {
         docs: {
             description: "Disallow usage of the `any` type",
             extraDescription: [util.tslintRule("no-any")],
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-explicit-any.md"
         },
         schema: []
     },

--- a/lib/rules/no-namespace.js
+++ b/lib/rules/no-namespace.js
@@ -13,7 +13,9 @@ module.exports = {
         docs: {
             description:
                 "Disallow the use of custom TypeScript modules and namespaces",
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-namespace.md"
         },
         schema: [
             {

--- a/lib/rules/no-parameter-properties.js
+++ b/lib/rules/no-parameter-properties.js
@@ -16,7 +16,9 @@ module.exports = {
             description:
                 "Disallow the use of parameter properties in class constructors.",
             extraDescription: [util.tslintRule("no-parameter-properties")],
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-parameter-properties.md"
         },
         schema: [
             {

--- a/lib/rules/no-triple-slash-reference.js
+++ b/lib/rules/no-triple-slash-reference.js
@@ -15,7 +15,9 @@ module.exports = {
         docs: {
             description: 'Disallow `/// <reference path="" />` comments',
             extraDescription: [util.tslintRule("no-reference")],
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-triple-slash-reference.md"
         },
         schema: []
     },

--- a/lib/rules/no-type-alias.js
+++ b/lib/rules/no-type-alias.js
@@ -15,7 +15,9 @@ module.exports = {
         docs: {
             description: "Disallow the use of type aliases",
             extraDescription: [util.tslintRule("interface-over-type-literal")],
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-type-alias.md"
         },
         schema: [
             {

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -49,7 +49,9 @@ module.exports = {
             description:
                 "Prevent TypeScript-specific constructs from being erroneously flagged as unused",
             category: "TypeScript",
-            recommended: true
+            recommended: true,
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-unused-vars.md"
         },
         schema: []
     },

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -158,7 +158,9 @@ module.exports = {
             description:
                 "Disallow the use of variables before they are defined",
             category: "Variables",
-            recommended: false
+            recommended: false,
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-use-before-define.md"
         },
 
         schema: [

--- a/lib/rules/prefer-namespace-keyword.js
+++ b/lib/rules/prefer-namespace-keyword.js
@@ -16,7 +16,9 @@ module.exports = {
             description:
                 "Require the use of the `namespace` keyword instead of the `module` keyword to declare custom TypeScript modules.",
             extraDescription: [util.tslintRule("no-internal-module")],
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/prefer-namespace-keyword.md"
         },
         fixable: "code",
         schema: []

--- a/lib/rules/type-annotation-spacing.js
+++ b/lib/rules/type-annotation-spacing.js
@@ -22,7 +22,9 @@ module.exports = {
     meta: {
         docs: {
             description: "Require consistent spacing around type annotations",
-            category: "TypeScript"
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/type-annotation-spacing.md"
         },
         fixable: "code",
         schema: [


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.