### PR TITLE
Chore: Update typescript-eslint-parser and typescript

### DIFF
--- a/lib/rules/adjacent-overload-signatures.js
+++ b/lib/rules/adjacent-overload-signatures.js
@@ -44,7 +44,9 @@ module.exports = {
                 }
                 case "DeclareFunction":
                 case "FunctionDeclaration":
-                case "TSNamespaceFunctionDeclaration": {
+                case "TSNamespaceFunctionDeclaration":
+                case "TSEmptyBodyFunctionDeclaration":
+                case "TSEmptyBodyDeclareFunction": {
                     return member.id.name;
                 }
                 case "TSMethodSignature": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "lint-staged": "^6.0.0",
     "mocha": "^4.0.1",
     "prettier": "^1.11.1",
-    "typescript": "~2.6.1",
-    "typescript-eslint-parser": "^10.0.0"
+    "typescript": "~2.8.1",
+    "typescript-eslint-parser": "^15.0.0"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
This PR updates typescript-eslint-parser and typescript to the latest versions.

The only breaking change in typescript-eslint-parser I could find was in https://github.com/eslint/typescript-eslint-parser/pull/412, which added the `TSEmptyBody` types. Some of the `adjacent-overload-signatures` tests were failing, but adding the `TSEmptyBody` node types to the rule fixed those tests.

If there is something else to be aware of in this update or if there's a better commit message name, please let me know! 😄 