### PR TITLE
Chore: Update prettier to v1.11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^6.0.0",
     "mocha": "^4.0.1",
-    "prettier": "1.9.1",
+    "prettier": "^1.11.1",
     "typescript": "~2.6.1",
     "typescript-eslint-parser": "^10.0.0"
   },


### PR DESCRIPTION
Changes since v1.9.x:

* https://prettier.io/blog/2018/01/10/1.10.0.html
* https://prettier.io/blog/2018/02/26/1.11.0.html

I also ran `npx prettier --tab-width=4 **/*.js --write` after updating, and no files were changed as a result.