### PR TITLE
Update: allow expression exclusion from return type checks

### DIFF
--- a/docs/rules/explicit-function-return-type.md
+++ b/docs/rules/explicit-function-return-type.md
@@ -63,6 +63,9 @@ The rule accepts an options object with the following properties:
 
 * `allowExpressions` if true, only functions which are part of a declaration will be checked
 
+By default, `allowExpressions: false` is used, meaning all declarations and
+expressions _must_ have a return type.
+
 ### allowExpressions
 
 Examples of **incorrect** code for this rule with `{ allowExpressions: true }`:

--- a/docs/rules/explicit-function-return-type.md
+++ b/docs/rules/explicit-function-return-type.md
@@ -55,15 +55,6 @@ class Test {
         return;
     }
 }
-
-/*eslint explicit-function-return-type: ["error", { allowExpressions: true }]*/
-node.addEventListener('click', () => {});
-
-/*eslint explicit-function-return-type: ["error", { allowExpressions: true }]*/
-node.addEventListener('click', function() {});
-
-/*eslint explicit-function-return-type: ["error", { allowExpressions: true }]*/
-const foo = arr.map(i => i * i);
 ```
 
 ## Options
@@ -71,6 +62,25 @@ const foo = arr.map(i => i * i);
 The rule accepts an options object with the following properties:
 
 * `allowExpressions` if true, only functions which are part of a declaration will be checked
+
+### allowExpressions
+
+Examples of *incorrect* code for this rule with `{ allowExpressions: true }`:
+
+```ts
+function test() {
+}
+```
+
+Examples of *correct* code for this rule with `{ allowExpressions: true }`:
+
+```ts
+node.addEventListener('click', () => {});
+
+node.addEventListener('click', function() {});
+
+const foo = arr.map(i => i * i);
+```
 
 ## When Not To Use It
 

--- a/docs/rules/explicit-function-return-type.md
+++ b/docs/rules/explicit-function-return-type.md
@@ -65,14 +65,14 @@ The rule accepts an options object with the following properties:
 
 ### allowExpressions
 
-Examples of *incorrect* code for this rule with `{ allowExpressions: true }`:
+Examples of **incorrect** code for this rule with `{ allowExpressions: true }`:
 
 ```ts
 function test() {
 }
 ```
 
-Examples of *correct* code for this rule with `{ allowExpressions: true }`:
+Examples of **correct** code for this rule with `{ allowExpressions: true }`:
 
 ```ts
 node.addEventListener('click', () => {});

--- a/docs/rules/explicit-function-return-type.md
+++ b/docs/rules/explicit-function-return-type.md
@@ -55,7 +55,22 @@ class Test {
         return;
     }
 }
+
+/*eslint explicit-function-return-type: ["error", { allowExpressions: true }]*/
+node.addEventListener('click', () => {});
+
+/*eslint explicit-function-return-type: ["error", { allowExpressions: true }]*/
+node.addEventListener('click', function() {});
+
+/*eslint explicit-function-return-type: ["error", { allowExpressions: true }]*/
+const foo = arr.map(i => i * i);
 ```
+
+## Options
+
+The rule accepts an options object with the following properties:
+
+* `allowExpressions` if true, only functions which are part of a declaration will be checked
 
 ## When Not To Use It
 

--- a/lib/rules/explicit-function-return-type.js
+++ b/lib/rules/explicit-function-return-type.js
@@ -20,10 +20,22 @@ module.exports = {
             url:
                 "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/explicit-function-return-type.md"
         },
-        schema: []
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowExpressions: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
     },
 
     create(context) {
+        const options = context.options[0] || {};
+
         //----------------------------------------------------------------------
         // Helpers
         //----------------------------------------------------------------------
@@ -58,6 +70,14 @@ module.exports = {
          * @private
          */
         function checkFunctionReturnType(node) {
+            if (
+                options.allowExpressions &&
+                node.type !== "FunctionDeclaration" &&
+                node.parent.type !== "VariableDeclarator"
+            ) {
+                return;
+            }
+
             if (
                 !node.returnType &&
                 !isConstructor(node.parent) &&

--- a/tests/lib/rules/explicit-function-return-type.js
+++ b/tests/lib/rules/explicit-function-return-type.js
@@ -65,6 +65,46 @@ function test() {
     return;
 }
             `
+        },
+        {
+            code: `fn(() => {});`,
+            options: [
+                {
+                    allowExpressions: true
+                }
+            ]
+        },
+        {
+            code: `fn(function() {});`,
+            options: [
+                {
+                    allowExpressions: true
+                }
+            ]
+        },
+        {
+            code: `[function() {}, () => {}]`,
+            options: [
+                {
+                    allowExpressions: true
+                }
+            ]
+        },
+        {
+            code: `(function() {});`,
+            options: [
+                {
+                    allowExpressions: true
+                }
+            ]
+        },
+        {
+            code: `(() => {})();`,
+            options: [
+                {
+                    allowExpressions: true
+                }
+            ]
         }
     ],
     invalid: [
@@ -135,6 +175,30 @@ class Test {
                     message: "Missing return type on function.",
                     line: 8,
                     column: 9
+                }
+            ]
+        },
+        {
+            filename: "test.ts",
+            code: `const foo = () => {};`,
+            options: [{ allowExpressions: true }],
+            errors: [
+                {
+                    message: "Missing return type on function.",
+                    line: 1,
+                    column: 13
+                }
+            ]
+        },
+        {
+            filename: "test.ts",
+            code: `const foo = function() {};`,
+            options: [{ allowExpressions: true }],
+            errors: [
+                {
+                    message: "Missing return type on function.",
+                    line: 1,
+                    column: 13
                 }
             ]
         }


### PR DESCRIPTION
Fixes #123.

Added an option to exclude arrow functions from the explicit return type rule. Seems to be a common exclusion plenty would appreciate.

So code like this can be excluded from the rule:

```ts
arr.filter((item) => item + 1);
```

Personal preference but one could argue it is over the top to require a return type on the above. So figured why not make it a choice.