### PR TITLE
Fix: prefer-namespace-keyword false positive (fixes #127)

### DIFF
--- a/lib/rules/prefer-namespace-keyword.js
+++ b/lib/rules/prefer-namespace-keyword.js
@@ -28,47 +28,31 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
         //----------------------------------------------------------------------
-        // Helpers
-        //----------------------------------------------------------------------
-
-        /**
-         * Determines if node is a TypeScript module declaration (instead of a namespace/module).
-         * @param {ASTNode} node the node to be evaluated.
-         * @returns {boolean} true when node is an external declaration.
-         * @private
-         */
-        function isTypeScriptModuleDeclaration(node) {
-            return node.id && node.id.type === "Literal";
-        }
-
-        /**
-         * Gets the start index of the keyword `module`.
-         * @param {TSNode} node the node to be evaluated.
-         * @returns {number} the start index.
-         * @private
-         */
-        function getStartIndex(node) {
-            if (
-                node.modifiers &&
-                node.modifiers.length > 0 &&
-                node.modifiers[0].type === "TSDeclareKeyword"
-            ) {
-                return node.range[0] + "declare".length + 1;
-            }
-            return node.range[0];
-        }
-
-        //----------------------------------------------------------------------
         // Public
         //----------------------------------------------------------------------
         return {
             TSModuleDeclaration(node) {
-                const declaration = sourceCode.getText(node);
+                // Get tokens of the declaration header.
+                const firstToken = sourceCode.getFirstToken(node);
+                const tokens = [firstToken].concat(
+                    sourceCode.getTokensBetween(
+                        firstToken,
+                        sourceCode.getFirstToken(node.body)
+                    )
+                );
 
-                if (
-                    isTypeScriptModuleDeclaration(node) ||
-                    /\bnamespace\b/.test(declaration)
-                ) {
+                // Get 'module' token and the next one.
+                const moduleKeywordIndex = tokens.findIndex(
+                    t => t.type === "Identifier" && t.value === "module"
+                );
+                const moduleKeywordToken =
+                    moduleKeywordIndex === -1
+                        ? null
+                        : tokens[moduleKeywordIndex];
+                const moduleNameToken = tokens[moduleKeywordIndex + 1];
+
+                // Do nothing if the 'module' token was not found or the module name is a string.
+                if (!moduleKeywordToken || moduleNameToken.type === "String") {
                     return;
                 }
 
@@ -77,10 +61,8 @@ module.exports = {
                     message:
                         "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
                     fix(fixer) {
-                        const start = getStartIndex(node);
-
-                        return fixer.replaceTextRange(
-                            [start, start + "module".length],
+                        return fixer.replaceText(
+                            moduleKeywordToken,
                             "namespace"
                         );
                     }

--- a/tests/lib/rules/prefer-namespace-keyword.js
+++ b/tests/lib/rules/prefer-namespace-keyword.js
@@ -23,7 +23,8 @@ ruleTester.run("prefer-namespace-keyword", rule, {
     valid: [
         "declare module 'foo' { }",
         "namespace foo { }",
-        "declare namespace foo { }"
+        "declare namespace foo { }",
+        "declare global { }"
     ],
     invalid: [
         {


### PR DESCRIPTION
Fixes #127.

This PR fixes false positive of `prefer-namespace-keyword` token.

The new logic is more robust because it's token-based instead of text-based. That rule reports `module` keyword to suggest a use of `namespace` keyword, so the new logic finds `module` keyword token. Previously, it reported the declaration if `namespace` keyword was not found, even if `module` keyword was not found.