### PR TITLE
Fix: Handle extends generics in no-unused-vars

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -126,6 +126,11 @@ module.exports = {
                     markTypeAnnotationAsUsed(annotation.constraint);
                     break;
                 }
+                case "TSMappedType": {
+                    markTypeAnnotationAsUsed(annotation.typeAnnotation);
+                    markTypeAnnotationAsUsed(annotation.typeParameter);
+                    break;
+                }
                 default:
                     break;
             }

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -122,6 +122,10 @@ module.exports = {
 
                     break;
 
+                case "TSTypeParameter": {
+                    markTypeAnnotationAsUsed(annotation.constraint);
+                    break;
+                }
                 default:
                     break;
             }
@@ -246,6 +250,9 @@ module.exports = {
             }
             if (node.decorators) {
                 node.decorators.forEach(markDecoratorAsUsed);
+            }
+            if (node.typeParameters && node.typeParameters.params) {
+                node.typeParameters.params.forEach(markTypeAnnotationAsUsed);
             }
         }
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -330,6 +330,16 @@ import { Foo, Bar } from './types';
 class Baz<T extends Foo & Bar> {}
 
 new Baz<any>()
+        `,
+        `
+type Foo = "a" | "b" | "c"
+type Bar = number
+
+export const map: { [name in Foo]: Bar } = {
+    a: 1,
+    b: 2,
+    c: 3
+}
         `
     ],
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -323,6 +323,13 @@ import { Foo } from './types';
 class Bar<T extends Foo> {}
 
 new Bar<number>()
+        `,
+        `
+import { Foo, Bar } from './types';
+
+class Baz<T extends Foo & Bar> {}
+
+new Baz<any>()
         `
     ],
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -316,6 +316,13 @@ import { Another } from 'some';
 interface A extends Nullable<SomeOther> {
     do(a: Nullable<Another>);
 }
+        `,
+        `
+import { Foo } from './types';
+
+class Bar<T extends Foo> {}
+
+new Bar<number>()
         `
     ],
 


### PR DESCRIPTION
See #33 

I believe this addresses the first and fourth snippets in https://github.com/nzakas/eslint-plugin-typescript/issues/33#issuecomment-399316751. Any thoughts on other test cases to add or things to consider in this fix?

[Here is a link](http://astexplorer.net/#/gist/2e4055c6371619d206d0f39184c6f835/efbf815025efdfdaa8d6edd3880c8c41b56d1d9a) to an AST Explorer of the test case, if that is helpful for review.