### PR TITLE
add type alias to pascal casing rule

### DIFF
--- a/docs/rules/class-name-casing.md
+++ b/docs/rules/class-name-casing.md
@@ -22,6 +22,8 @@ var bar = class invalidName {}
 
 interface someInterface {}
 
+type someTypeAlias = number;
+
 ```
 
 Examples of **correct** code for this rule:
@@ -39,6 +41,8 @@ export default class {
 var foo = class {};
 
 interface SomeInterface {}
+
+type SomeTypeAlias = number;
 
 ```
 

--- a/lib/rules/class-name-casing.js
+++ b/lib/rules/class-name-casing.js
@@ -42,12 +42,11 @@ module.exports = {
          * Report a class declaration as invalid
          * @param   {Node} decl              The declaration
          * @param   {Node} [id=classDecl.id] The name of the declaration
+         * @param   {Node} [friendlyName=classDecl.type] The printable name of the declaration
          * @returns {undefined}
          */
-        function report(decl, id) {
+        function report(decl, id, friendlyName) {
             id = id || decl.id;
-
-            let friendlyName;
 
             switch (decl.type) {
                 case "ClassDeclaration":
@@ -58,7 +57,7 @@ module.exports = {
                     friendlyName = "Interface";
                     break;
                 default:
-                    friendlyName = decl.type;
+                    friendlyName = friendlyName || decl.type;
             }
 
             context.report({
@@ -86,6 +85,10 @@ module.exports = {
                         report(node.init);
                     } else if (id && !isPascalCase(id.name)) {
                         report(node.init, id);
+                    }
+                } else if (node.parent.kind === "type") {
+                    if (!isPascalCase(node.id.name)) {
+                        report(node, node.id, "Type alias");
                     }
                 }
             }

--- a/tests/lib/rules/class-name-casing.js
+++ b/tests/lib/rules/class-name-casing.js
@@ -30,7 +30,8 @@ ruleTester.run("class-name-casing", rule, {
         },
         "var Foo = class {};",
         "interface SomeInterface {}",
-        "class ClassNameWithDigit2 {}"
+        "class ClassNameWithDigit2 {}",
+        "type Cool = number"
     ],
 
     invalid: [
@@ -82,6 +83,16 @@ ruleTester.run("class-name-casing", rule, {
                     message: "Interface 'someInterface' must be PascalCased",
                     line: 1,
                     column: 11
+                }
+            ]
+        },
+        {
+            code: "type someTypeAlias = number",
+            errors: [
+                {
+                    message: "Type alias 'someTypeAlias' must be PascalCased",
+                    line: 1,
+                    column: 6
                 }
             ]
         }


### PR DESCRIPTION
Enforce Pascal casing for type alias identifiers, in addition to the interface and class definitions already being checked.