### PR TITLE
fix-plugin-crashing-on-function-declaration-without-member.id

### DIFF
--- a/lib/rules/adjacent-overload-signatures.js
+++ b/lib/rules/adjacent-overload-signatures.js
@@ -47,7 +47,7 @@ module.exports = {
                 case "TSNamespaceFunctionDeclaration":
                 case "TSEmptyBodyFunctionDeclaration":
                 case "TSEmptyBodyDeclareFunction": {
-                    return member.id.name;
+                    return member.id && member.id.name;
                 }
                 case "TSMethodSignature": {
                     return (


### PR DESCRIPTION
Fixes eslint-plugin-typescript crashing on function declaration without member.id

(I've been experiencing this problem & tested the fix on my code)