### PR TITLE
Fix adjacent-overload-signatures barfing on no-name, generic, default exports

### DIFF
--- a/lib/rules/adjacent-overload-signatures.js
+++ b/lib/rules/adjacent-overload-signatures.js
@@ -47,7 +47,11 @@ module.exports = {
                 case "TSNamespaceFunctionDeclaration":
                 case "TSEmptyBodyFunctionDeclaration":
                 case "TSEmptyBodyDeclareFunction": {
-                    return member.id.name;
+                    if (member.id) {
+                        return member.id.name;
+                    }
+
+                    return null;
                 }
                 case "TSMethodSignature": {
                     return (

--- a/tests/lib/rules/adjacent-overload-signatures.js
+++ b/tests/lib/rules/adjacent-overload-signatures.js
@@ -212,7 +212,10 @@ class Foo {
     bar(): void {}
     baz(): void {}
 }
-        `
+        `,
+        // examples from https://github.com/nzakas/eslint-plugin-typescript/issues/138
+        "export default function<T>(foo : T) {}",
+        "export default function named<T>(foo : T) {}"
     ],
     invalid: [
         {


### PR DESCRIPTION
Fixes #138 