### PR TITLE
[FIX] [generic-type-naming] Add rule

### DIFF
--- a/lib/rules/generic-type-naming.js
+++ b/lib/rules/generic-type-naming.js
@@ -1,44 +1,11 @@
 /**
  * @fileoverview Enforces naming of generic type variables.
+ * @author Roman Vasilev
+ * @author Armano <https://github.com/armano2>
  */
 "use strict";
 
 const util = require("../util");
-
-/**
- *
- * @param {any} context ESLint context
- * @param {string} rule Option
- * @returns {Function} Node's visitor function
- */
-function createTypeParameterChecker(context, rule) {
-    const regex = new RegExp(rule);
-
-    return function checkTypeParameters(pnode) {
-        const params = pnode.typeParameters && pnode.typeParameters.params;
-
-        if (!Array.isArray(params) || params.length === 0) {
-            return;
-        }
-        params.forEach(node => {
-            const type = node.type;
-
-            if (type === "TSTypeParameter" || type === "TypeParameter") {
-                const name = node.name;
-
-                if (name && !regex.test(name)) {
-                    const data = { name, rule };
-
-                    context.report({
-                        node,
-                        messageId: "paramNotMatchRule",
-                        data,
-                    });
-                }
-            }
-        });
-    };
-}
 
 const defaultOptions = [
     // Matches: T , TA , TAbc , TA1Bca , T1 , T2
@@ -67,16 +34,22 @@ module.exports = {
 
     create(context) {
         const rule = util.applyDefault(defaultOptions, context.options)[0];
-        const checkTypeParameters = createTypeParameterChecker(context, rule);
+        const regex = new RegExp(rule);
 
         return {
-            VariableDeclarator: checkTypeParameters,
-            ClassDeclaration: checkTypeParameters,
-            InterfaceDeclaration: checkTypeParameters,
-            TSInterfaceDeclaration: checkTypeParameters,
-            FunctionDeclaration: checkTypeParameters,
-            TSCallSignature: checkTypeParameters,
-            CallSignature: checkTypeParameters,
+            TSTypeParameter(node) {
+                const name = node.name;
+
+                if (name && !regex.test(name)) {
+                    const data = { name, rule };
+
+                    context.report({
+                        node,
+                        messageId: "paramNotMatchRule",
+                        data,
+                    });
+                }
+            },
         };
     },
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "requireindex": "^1.2.0",
-    "typescript-eslint-parser": "21.0.2"
+    "typescript-eslint-parser": "git+https://github.com/armano2/typescript-eslint-parser.git#42f1801cdc9e26b271ab8ad7f8399669118ff34b"
   },
   "devDependencies": {
     "eslint": "^5.9.0",

--- a/tests/lib/rules/generic-type-naming.js
+++ b/tests/lib/rules/generic-type-naming.js
@@ -1,3 +1,8 @@
+/**
+ * @fileoverview Enforces naming of generic type variables.
+ * @author Roman Vasilev
+ * @author Armano <https://github.com/armano2>
+ */
 "use strict";
 
 //------------------------------------------------------------------------------
@@ -23,6 +28,21 @@ ruleTester.run("generic-type-naming", rule, {
         { code: "function get<T>() {}", options: [] },
         { code: "interface GenericIdentityFn { <T>(arg: T): T }", options: [] },
         { code: "class<x> { }", options: ["^x+$"] },
+        { code: "class<A> { }", options: ["^[A-Z]$"] },
+        {
+            code: "class<A> extends B<Test> implements Foo<Test> { }",
+            options: ["^[A-Z]$"],
+        },
+        {
+            code: `
+class<A> extends B<Test> implements Foo<Test> {
+    test<Z> () {
+        type Foo = Bar<Test>
+    }
+}
+            `,
+            options: ["^[A-Z]$"],
+        },
         {
             code: "class CounterContainer extends Container<Counter> { }",
             options: ["^T$"],
@@ -50,6 +70,8 @@ ruleTester.run("generic-type-naming", rule, {
                 {
                     messageId: "paramNotMatchRule",
                     data: { name: "x", rule: "^[A-Z]+$" },
+                    line: 1,
+                    column: 7,
                 },
             ],
         },
@@ -60,6 +82,8 @@ ruleTester.run("generic-type-naming", rule, {
                 {
                     messageId: "paramNotMatchRule",
                     data: { name: "x", rule: "^[A-Z]+$" },
+                    line: 1,
+                    column: 21,
                 },
             ],
         },
@@ -70,6 +94,8 @@ ruleTester.run("generic-type-naming", rule, {
                 {
                     messageId: "paramNotMatchRule",
                     data: { name: "x", rule: "^[A-Z]+$" },
+                    line: 1,
+                    column: 8,
                 },
             ],
         },
@@ -80,6 +106,8 @@ ruleTester.run("generic-type-naming", rule, {
                 {
                     messageId: "paramNotMatchRule",
                     data: { name: "x", rule: "^[A-Z]+$" },
+                    line: 1,
+                    column: 14,
                 },
             ],
         },
@@ -90,6 +118,74 @@ ruleTester.run("generic-type-naming", rule, {
                 {
                     messageId: "paramNotMatchRule",
                     data: { name: "x", rule: "^[A-Z]+$" },
+                    line: 1,
+                    column: 32,
+                },
+            ],
+        },
+        {
+            code: `
+class<A> extends B<Test> implements Foo<Test> {
+    test<Z> () {
+        type Foo<T> = Bar<Test>
+    }
+}
+            `,
+            options: ["^[A-Z][0-9]$"],
+            errors: [
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "A", rule: "^[A-Z][0-9]$" },
+                    line: 2,
+                    column: 7,
+                },
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "Z", rule: "^[A-Z][0-9]$" },
+                    line: 3,
+                    column: 10,
+                },
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "T", rule: "^[A-Z][0-9]$" },
+                    line: 4,
+                    column: 18,
+                },
+            ],
+        },
+        {
+            code: `
+abstract class<A, B> extends B<Test> implements Foo<Test> {
+    test<Z> () {
+        type Foo<T> = Bar<Test>
+    }
+}
+            `,
+            options: ["^[A-Z][0-9]$"],
+            errors: [
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "A", rule: "^[A-Z][0-9]$" },
+                    line: 2,
+                    column: 16,
+                },
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "B", rule: "^[A-Z][0-9]$" },
+                    line: 2,
+                    column: 19,
+                },
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "Z", rule: "^[A-Z][0-9]$" },
+                    line: 3,
+                    column: 10,
+                },
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "T", rule: "^[A-Z][0-9]$" },
+                    line: 4,
+                    column: 18,
                 },
             ],
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3372,15 +3372,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-eslint-parser@21.0.2:
-  version "21.0.2"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-21.0.2.tgz#270af10e4724528677fbcf34ea495284bec3a894"
-  integrity sha512-u+pj4RVJBr4eTzj0n5npoXD/oRthvfUCjSKndhNI714MG0mQq2DJw5WP7qmonRNIFgmZuvdDOH3BHm9iOjIAfg==
-  dependencies:
-    eslint-scope "^4.0.0"
-    eslint-visitor-keys "^1.0.0"
-    typescript-estree "5.3.0"
-
 typescript-eslint-parser@^16.0.0:
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-16.0.1.tgz#b40681c7043b222b9772748b700a000b241c031b"
@@ -3388,6 +3379,14 @@ typescript-eslint-parser@^16.0.0:
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
+
+"typescript-eslint-parser@git+https://github.com/armano2/typescript-eslint-parser.git#42f1801cdc9e26b271ab8ad7f8399669118ff34b":
+  version "21.0.2"
+  resolved "git+https://github.com/armano2/typescript-eslint-parser.git#42f1801cdc9e26b271ab8ad7f8399669118ff34b"
+  dependencies:
+    eslint-scope "^4.0.0"
+    eslint-visitor-keys "^1.0.0"
+    typescript-estree "5.3.0"
 
 typescript-estree@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
This PR changes logic behind `generic-type-naming` and makes it more generic
- TSAbstracClassDeclaration and ***ClassExpression is going to be processed

#### Do not merge
- [x] implement rule
- [x] add tests
- [x] add documentation
- [ ] https://github.com/eslint/typescript-eslint-parser/pull/581 has to be merged first