### PR TITLE
[FEAT] Add 'callable-types' rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You can also enable all the recommended rules at once. Add `plugin:typescript/re
 | [`typescript/adjacent-overload-signatures`](./docs/rules/adjacent-overload-signatures.md) | Require that member overloads be consecutive (`adjacent-overload-signatures` from TSLint) | :heavy_check_mark: |  |
 | [`typescript/array-type`](./docs/rules/array-type.md) | Requires using either `T[]` or `Array<T>` for arrays (`array-type` from TSLint) | :heavy_check_mark: | :wrench: |
 | [`typescript/ban-types`](./docs/rules/ban-types.md) | Enforces that types will not to be used (`ban-types` from TSLint) | :heavy_check_mark: | :wrench: |
+| [`typescript/callable-types`](./docs/rules/callable-types.md) | Use function types instead of interfaces with call signatures (`callable-types` from TSLint) |  | :wrench: |
 | [`typescript/camelcase`](./docs/rules/camelcase.md) | Enforce camelCase naming convention | :heavy_check_mark: |  |
 | [`typescript/class-name-casing`](./docs/rules/class-name-casing.md) | Require PascalCased class and interface names (`class-name` from TSLint) | :heavy_check_mark: |  |
 | [`typescript/explicit-function-return-type`](./docs/rules/explicit-function-return-type.md) | Require explicit return types on functions and class methods | :heavy_check_mark: |  |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# Roadmap
+﻿# Roadmap
 
 ## TSLint rules
 
@@ -126,7 +126,7 @@
 | [`arrow-parens`]                    | 🌟  | [`arrow-parens`](https://eslint.org/docs/rules/arrow-parens)                                                                                                                                                                                                    |
 | [`arrow-return-shorthand`]          | 🌟  | [`arrow-body-style`](https://eslint.org/docs/rules/arrow-body-style)                                                                                                                                                                                            |
 | [`binary-expression-operand-order`] | 🌟  | [`yoda`](https://eslint.org/docs/rules/yoda)                                                                                                                                                                                                                    |
-| [`callable-types`]                  | 🛑  | N/A                                                                                                                                                                                                                                                             |
+| [`callable-types`]                  | ✅  | [`typescript/callable-types`]                                                                                                                                                                                                                                   |
 | [`class-name`]                      | ✅  | [`typescript/class-name-casing`]                                                                                                                                                                                                                                |
 | [`comment-format`]                  | 🌟  | [`capitalized-comments`](https://eslint.org/docs/rules/capitalized-comments) & [`spaced-comment`](https://eslint.org/docs/rules/spaced-comment)                                                                                                                 |
 | [`completed-docs`]                  | 🔌  | [`eslint-plugin-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc)                                                                                                                                                                                           |

--- a/docs/rules/callable-types.md
+++ b/docs/rules/callable-types.md
@@ -1,0 +1,36 @@
+# Use function types instead of interfaces with call signatures (callable-types)
+
+Please describe the origin of the rule here.
+
+
+## Rule Details
+
+This rule aims to...
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+### Options
+
+If there are any options, describe them here. Otherwise, delete this section.
+
+## When Not To Use It
+
+Give a short description of when it would be appropriate to turn off this rule.
+
+## Further Reading
+
+If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/docs/rules/callable-types.md
+++ b/docs/rules/callable-types.md
@@ -54,4 +54,4 @@ If you specifically want to use an interface or type literal with a single call 
 
 ## Further Reading
 
--   TSLint: ['callable-types'](https://palantir.github.io/tslint/rules/callable-types/)
+-   TSLint: [`callable-types`](https://palantir.github.io/tslint/rules/callable-types/)

--- a/docs/rules/callable-types.md
+++ b/docs/rules/callable-types.md
@@ -1,36 +1,57 @@
 # Use function types instead of interfaces with call signatures (callable-types)
 
-Please describe the origin of the rule here.
-
-
 ## Rule Details
 
-This rule aims to...
+This rule suggests using a function type instead of an interface or object type literal with a single call signature.
 
 Examples of **incorrect** code for this rule:
 
-```js
+```ts
+interface Foo {
+    (): string;
+}
+```
 
-// fill me in
+```ts
+function foo(bar: { (): number }): number {
+    return bar();
+}
+```
 
+```ts
+interface Foo extends Function {
+    (): void;
+}
 ```
 
 Examples of **correct** code for this rule:
 
-```js
-
-// fill me in
-
+```ts
+interface Foo {
+    (): void;
+    bar: number;
+}
 ```
 
-### Options
+```ts
+function foo(bar: { (): string; baz: number }): string {
+    return bar();
+}
+```
 
-If there are any options, describe them here. Otherwise, delete this section.
+```ts
+interface Foo {
+    bar: string;
+}
+interface Bar extends Foo {
+    (): void;
+}
+```
 
 ## When Not To Use It
 
-Give a short description of when it would be appropriate to turn off this rule.
+If you specifically want to use an interface or type literal with a single call signature for stylistic reasons, you can disable this rule.
 
 ## Further Reading
 
-If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.
+-   TSLint: ['callable-types'](https://palantir.github.io/tslint/rules/callable-types/)

--- a/lib/rules/callable-types.js
+++ b/lib/rules/callable-types.js
@@ -1,0 +1,196 @@
+/**
+ * @fileoverview Use function types instead of interfaces with call signatures
+ * @author Benjamin Lichtman
+ */
+"use strict";
+const ts = require("typescript");
+const tsutils = require("tsutils");
+const util = require("../util");
+
+/**
+ * @typedef {util.Context} Context
+ * @typedef {util.ESTreeNode} ESTreeNode
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "Use function types instead of interfaces with call signatures",
+            category: "Fill me in",
+            recommended: false
+        },
+        fixable: "code", // or "code" or "whitespace"
+        schema: [
+            // fill in your schema
+        ]
+    },
+
+    /**
+     * @param {Context} context ESLint rule context
+     * @returns {*} Rule listeners
+     */
+    create(context) {
+        // variables should be defined here
+
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+
+        /**
+         * @param {string} type The incorrect type of callable construct
+         * @param {string} sigSuggestion The recommended type of callable construct
+         * @returns {string} The error message
+         */
+        function failureMessage(type, sigSuggestion) {
+            return `${type} has only a call signature - use \`${sigSuggestion}\` instead.`;
+        }
+
+        /**
+         * Checks if there is no supertype or if the supertype is 'Function'
+         * @param {ESTreeNode} node The node being checked
+         * @returns {boolean} Returns true iff there is no supertype or if the supertype is 'Function'
+         */
+        function noSupertype(node) {
+            if (typeof node.heritage === "undefined") {
+                return true;
+            }
+            if (node.heritage.length !== 1) {
+                return false;
+            }
+            const expr = node.heritage[0].id;
+
+            return (
+                util.esTreeNodeHasKind(expr, ts.SyntaxKind.Identifier) &&
+                expr.name === "Function"
+            );
+        }
+
+        /**
+         * @param {ESTreeNode} parent The parent of the call signature causing the diagnostic
+         * @returns {boolean} true iff the parent node needs to be wrapped for readability
+         */
+        function shouldWrapSuggestion(parent) {
+            switch (parent.type) {
+                case util.getESTreeType(ts.SyntaxKind.UnionType):
+                case util.getESTreeType(ts.SyntaxKind.IntersectionType):
+                case util.getESTreeType(ts.SyntaxKind.ArrayType):
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /**
+         * @param {ESTreeNode} call The call signature causing the diagnostic
+         * @param {ESTreeNode} parent The parent of the call
+         * @returns {string} The suggestion to report
+         */
+        function renderSuggestion(call, parent) {
+            const sourceCode = context.getSourceCode();
+            const start = call.range[0];
+            const colonPos = call.typeAnnotation.range[0] - start;
+            const text = sourceCode.getText().substring(start, call.range[1]);
+
+            let suggestion = `${text.substr(0, colonPos)} =>${text.substr(
+                colonPos + 1
+            )}`;
+
+            if (shouldWrapSuggestion(parent.parent)) {
+                suggestion = `(${suggestion})`;
+            }
+            if (
+                util.esTreeNodeHasKind(
+                    parent,
+                    ts.SyntaxKind.InterfaceDeclaration
+                )
+            ) {
+                if (typeof parent.typeParameters !== "undefined") {
+                    return `type${sourceCode
+                        .getText()
+                        .substring(
+                            parent.name.pos,
+                            parent.typeParameters.end + 1
+                        )} = ${suggestion}`;
+                }
+                return `type ${parent.id.name} = ${suggestion}`;
+            }
+            return suggestion.endsWith(";")
+                ? suggestion.slice(0, -1)
+                : suggestion;
+        }
+
+        /**
+         * @param {ESTreeNode} member The potential call signature being checked
+         * @param {ESTreeNode} node The node being checked
+         * @returns {void}
+         */
+        function checkMember(member, node) {
+            if (
+                util.esTreeNodeHasKind(member, ts.SyntaxKind.CallSignature) &&
+                typeof member.typeAnnotation !== "undefined"
+            ) {
+                const suggestion = renderSuggestion(member, node);
+                const fixStart = util.esTreeNodeHasKind(
+                    node,
+                    ts.SyntaxKind.TypeLiteral
+                )
+                    ? node.range[0]
+                    : tsutils
+                          .getChildOfKind(
+                              context.parserServices.esTreeNodeToTSNodeMap.get(
+                                  node
+                              ),
+                              ts.SyntaxKind.InterfaceKeyword
+                          )
+                          .getStart();
+
+                context.report({
+                    node: member,
+                    message: failureMessage(
+                        util.esTreeNodeHasKind(node, ts.SyntaxKind.TypeLiteral)
+                            ? "Type literal"
+                            : "Interface",
+                        suggestion
+                    ),
+                    fix(fixer) {
+                        return fixer.replaceTextRange(
+                            [fixStart, node.range[1]],
+                            suggestion
+                        );
+                    }
+                });
+            }
+        }
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        return {
+            /**
+             * @param {ESTreeNode} node The node being checked
+             * @returns {void}
+             */
+            TSInterfaceDeclaration(node) {
+                if (noSupertype(node) && node.body.body.length === 1) {
+                    checkMember(node.body.body[0], node);
+                }
+            },
+            /**
+             * Won't work until type annotations are visited
+             * @param {ESTreeNode} node The node being checked
+             * @returns {void}
+             */
+            TSTypeLiteralNode(node) {
+                if (node.body.body.length === 1) {
+                    checkMember(node.body.body[0], node);
+                }
+            }
+        };
+    }
+};

--- a/lib/rules/callable-types.js
+++ b/lib/rules/callable-types.js
@@ -8,32 +8,32 @@ const tsutils = require("tsutils");
 const util = require("../util");
 
 /**
- * @typedef {util.Context} Context
- * @typedef {util.ESTreeNode} ESTreeNode
+ * @typedef {import("eslint").Rule.RuleModule} RuleModule
+ * @typedef {import("estree").Node} ESTreeNode
  */
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+ * @type {RuleModule}
+ */
 module.exports = {
     meta: {
         docs: {
             description:
                 "Use function types instead of interfaces with call signatures",
-            category: "Fill me in",
-            recommended: false
+            category: "Style",
+            recommended: false,
+            extraDescription: [util.tslintRule("callable-types")],
+            url: util.metaDocsUrl("callable-types"),
         },
         fixable: "code", // or "code" or "whitespace"
-        schema: [
-            // fill in your schema
-        ]
+        schema: [],
+        type: "suggestion",
     },
 
-    /**
-     * @param {Context} context ESLint rule context
-     * @returns {*} Rule listeners
-     */
     create(context) {
         // variables should be defined here
 
@@ -60,7 +60,7 @@ module.exports = {
                 return true;
             }
             if (node.heritage.length !== 1) {
-                return false;
+                return node.heritage.length === 0;
             }
             const expr = node.heritage[0].id;
 
@@ -94,9 +94,9 @@ module.exports = {
             const sourceCode = context.getSourceCode();
             const start = call.range[0];
             const colonPos = call.typeAnnotation.range[0] - start;
-            const text = sourceCode.getText().substring(start, call.range[1]);
+            const text = sourceCode.getText().slice(start, call.range[1]);
 
-            let suggestion = `${text.substr(0, colonPos)} =>${text.substr(
+            let suggestion = `${text.slice(0, colonPos)} =>${text.slice(
                 colonPos + 1
             )}`;
 
@@ -112,7 +112,7 @@ module.exports = {
                 if (typeof parent.typeParameters !== "undefined") {
                     return `type${sourceCode
                         .getText()
-                        .substring(
+                        .slice(
                             parent.name.pos,
                             parent.typeParameters.end + 1
                         )} = ${suggestion}`;
@@ -162,7 +162,7 @@ module.exports = {
                             [fixStart, node.range[1]],
                             suggestion
                         );
-                    }
+                    },
                 });
             }
         }
@@ -186,11 +186,14 @@ module.exports = {
              * @param {ESTreeNode} node The node being checked
              * @returns {void}
              */
-            TSTypeLiteralNode(node) {
-                if (node.body.body.length === 1) {
-                    checkMember(node.body.body[0], node);
+            TSTypeLiteral(node) {
+                if (
+                    util.esTreeNodeHasKind(node, ts.SyntaxKind.TypeLiteral) &&
+                    node.members.length === 1
+                ) {
+                    checkMember(node.members[0], node);
                 }
-            }
+            },
         };
-    }
+    },
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const parser = require("typescript-eslint-parser");
+const ts = require("typescript");
 const version = require("../package.json").version;
 
 exports.tslintRule = name => `\`${name}\` from TSLint`;
@@ -125,4 +127,25 @@ exports.getParserServices = context => {
         );
     }
     return context.parserServices;
+};
+
+/**
+ * @param {ts.SyntaxKind} syntaxKind A TS syntax kind
+ * @returns {string} The corresponding string representation
+ */
+function getESTreeType(syntaxKind) {
+    const tsSyntaxKindName = ts.SyntaxKind[syntaxKind];
+
+    return parser.Syntax[tsSyntaxKindName] || `TS${tsSyntaxKindName}`;
+}
+
+exports.getESTreeType = getESTreeType;
+
+/**
+ * @param {ESTreeNode} node An ESTree node
+ * @param {ts.SyntaxKind} kind A TS node kind
+ * @returns {boolean} Returns true iff the ESTree node has the corresponding TS kind
+ */
+exports.esTreeNodeHasKind = function(node, kind) {
+    return node.type === getESTreeType(kind);
 };

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   },
   "dependencies": {
     "requireindex": "^1.2.0",
+    "tsutils": "^3.6.0",
     "typescript-eslint-parser": "21.0.2"
   },
   "devDependencies": {
     "eslint": "^5.9.0",
-    "nyc": "^13.1.0",
     "eslint-config-eslint": "^5.0.1",
     "eslint-config-prettier": "^3.3.0",
     "eslint-docs": "^0.2.6",
@@ -42,6 +42,7 @@
     "husky": "^1.2.0",
     "lint-staged": "^8.1.0",
     "mocha": "^5.2.0",
+    "nyc": "^13.1.0",
     "prettier-eslint-cli": "^4.7.1",
     "typescript": "~3.1.1"
   },

--- a/tests/lib/fixtures/tsconfig.json
+++ b/tests/lib/fixtures/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "strict": true,
+        "esModuleInterop": true
+    }
+}

--- a/tests/lib/rules/callable-types.js
+++ b/tests/lib/rules/callable-types.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Use function types instead of interfaces with call signatures
+ * @author Benjamin Lichtman
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/callable-types"),
+
+    RuleTester = require("eslint").RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("callable-types", rule, {
+
+    valid: [
+
+        // give me some code that won't trigger a warning
+    ],
+
+    invalid: [
+        {
+            code: "interface Foo { (): string }",
+            errors: [{
+                message: "Fill me in.",
+                type: "Me too"
+            }]
+        }
+    ]
+});

--- a/tests/lib/rules/callable-types.js
+++ b/tests/lib/rules/callable-types.js
@@ -64,6 +64,8 @@ interface Foo {
                     type: "TSCallSignature",
                 },
             ],
+            output: `
+type Foo = () => string;`,
         },
         {
             code: `
@@ -76,18 +78,24 @@ type Foo = {
                     type: "TSCallSignature",
                 },
             ],
+            output: `
+type Foo = () => string`,
         },
         {
             code: `
-function foo(bar: { (): number }): number {
-    return bar();
+function foo(bar: { (s: string): number }): number {
+    return bar("hello");
 }`,
             errors: [
                 {
-                    message: `Type literal has only a call signature - use \`() => number\` instead.`,
+                    message: `Type literal has only a call signature - use \`(s: string) => number\` instead.`,
                     type: "TSCallSignature",
                 },
             ],
+            output: `
+function foo(bar: (s: string) => number): number {
+    return bar("hello");
+}`,
         },
         {
             code: `
@@ -100,6 +108,8 @@ interface Foo extends Function {
                     type: "TSCallSignature",
                 },
             ],
+            output: `
+type Foo = () => void;`,
         },
     ],
 });

--- a/tests/lib/rules/callable-types.js
+++ b/tests/lib/rules/callable-types.js
@@ -8,30 +8,98 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var rule = require("../../../lib/rules/callable-types"),
-
-    RuleTester = require("eslint").RuleTester;
-
+const rule = require("../../../lib/rules/callable-types"),
+    RuleTester = require("eslint").RuleTester,
+    path = require("path");
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-var ruleTester = new RuleTester();
+const rootDir = path.join(process.cwd(), "tests/lib/fixtures");
+const parserOptions = {
+    ecmaVersion: 2015,
+    tsconfigRootDir: rootDir,
+    project: "./tsconfig.json",
+};
+const ruleTester = new RuleTester({
+    parserOptions,
+    parser: "typescript-eslint-parser",
+});
+
 ruleTester.run("callable-types", rule, {
-
     valid: [
-
-        // give me some code that won't trigger a warning
+        `
+interface Foo {
+    (): void;
+    bar: number;
+}`,
+        `
+type Foo = {
+    (): void;
+    bar: number;
+}`,
+        `
+function foo(bar: { (): string, baz: number }): string {
+    return bar();
+}`,
+        `
+interface Foo {
+    bar: string;
+}
+interface Bar extends Foo {
+    (): void;
+}`,
     ],
 
     invalid: [
         {
-            code: "interface Foo { (): string }",
-            errors: [{
-                message: "Fill me in.",
-                type: "Me too"
-            }]
-        }
-    ]
+            code: `
+interface Foo {
+    (): string;
+}`,
+            errors: [
+                {
+                    message: `Interface has only a call signature - use \`type Foo = () => string;\` instead.`,
+                    type: "TSCallSignature",
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    (): string;
+}`,
+            errors: [
+                {
+                    message: `Type literal has only a call signature - use \`() => string\` instead.`,
+                    type: "TSCallSignature",
+                },
+            ],
+        },
+        {
+            code: `
+function foo(bar: { (): number }): number {
+    return bar();
+}`,
+            errors: [
+                {
+                    message: `Type literal has only a call signature - use \`() => number\` instead.`,
+                    type: "TSCallSignature",
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo extends Function {
+    (): void;
+}`,
+            errors: [
+                {
+                    message: `Interface has only a call signature - use \`type Foo = () => void;\` instead.`,
+                    type: "TSCallSignature",
+                },
+            ],
+        },
+    ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3355,10 +3355,17 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tsutils@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.6.0.tgz#33fc3ddb74abf5bba10789acd03eee6ea96c839c"
+  integrity sha512-hCG3lZz+uRmmiC4brr/kY6Yuypnl20PNe8t49DO4OUGlbxWkxYHF63EeG2XPSd0JcKiWmp9p55yQyrkxqSS5Dg==
+  dependencies:
+    tslib "^1.8.1"
 
 type-check@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
<!-- Before opening a pull request, either check (`[ ]` → `[x]`) or remove each of these entries) -->

<!-- If adding a rule -->

-   [x] I’ve filled out the documentation, including all relevant sections and a link to the equivalent TSLint rule if available.
-   [x] I’ve filled out the rule’s category
-   [x] I’ve added documentation for the equivalent TSLint rule (in `extraDescription`)
-   [x] I’ve added the rule documentation link via the helper from `../utils`.
-   [x] I’ve added the rule to the [roadmap](https://github.com/bradzacher/eslint-plugin-typescript/blob/master/ROADMAP.md)

<!-- All PRs that change code -->

-   [x] I’ve added tests for my changes

Adds callable-types rule from TSLint. Depends on https://github.com/eslint/typescript-eslint-parser/pull/568 for node mapping.